### PR TITLE
refactor: rename core/TUIAgent to PtyTerminal, fix TestScenario type conflict (#14, #25)

### DIFF
--- a/src/__tests__/TUIAgent.test.ts
+++ b/src/__tests__/TUIAgent.test.ts
@@ -1,14 +1,14 @@
-import { TUIAgent } from '../core/TUIAgent';
+import { PtyTerminal } from '../core/PtyTerminal';
 import { ProcessLifecycleManager } from '../core/ProcessLifecycleManager';
 import { waitForTerminalReady, delay } from '../core/AdaptiveWaiter';
 
-describe('TUIAgent', () => {
-  let agent: TUIAgent;
+describe('PtyTerminal', () => {
+  let agent: PtyTerminal;
   let processManager: ProcessLifecycleManager;
 
   beforeEach(() => {
     processManager = new ProcessLifecycleManager();
-    agent = new TUIAgent({}, processManager);
+    agent = new PtyTerminal({}, processManager);
   });
 
   afterEach(async () => {
@@ -19,7 +19,7 @@ describe('TUIAgent', () => {
 
   describe('Initialization', () => {
     it('should initialize with default configuration', () => {
-      const agent = new TUIAgent();
+      const agent = new PtyTerminal();
       expect(agent).toBeDefined();
       expect(agent.isRunning()).toBe(false);
     });
@@ -31,12 +31,12 @@ describe('TUIAgent', () => {
         timeout: 60000
       };
 
-      const agent = new TUIAgent(config);
+      const agent = new PtyTerminal(config);
       expect(agent).toBeDefined();
     });
 
     it('should detect shell based on platform', () => {
-      const agent = new TUIAgent();
+      const agent = new PtyTerminal();
       // Should not throw and should have a valid shell configured
       expect(agent).toBeDefined();
     });
@@ -56,13 +56,13 @@ describe('TUIAgent', () => {
     it('should prevent double start', async () => {
       await agent.start();
 
-      await expect(agent.start()).rejects.toThrow('TUIAgent is already started');
+      await expect(agent.start()).rejects.toThrow('PtyTerminal is already started');
     });
 
     it('should prevent start after destroy', async () => {
       await agent.destroy();
 
-      await expect(agent.start()).rejects.toThrow('Cannot start a destroyed TUIAgent');
+      await expect(agent.start()).rejects.toThrow('Cannot start a destroyed PtyTerminal');
     });
 
     it('should handle process ready event', async () => {
@@ -186,7 +186,7 @@ describe('TUIAgent', () => {
 
       await expect(
         agent.executeCommand('echo "test"')
-      ).rejects.toThrow('TUIAgent is not started or is destroyed');
+      ).rejects.toThrow('PtyTerminal is not started or is destroyed');
     });
   });
 
@@ -218,7 +218,7 @@ describe('TUIAgent', () => {
 
       expect(() => {
         agent.resize({ cols: 80, rows: 24 });
-      }).toThrow('TUIAgent is not started or is destroyed');
+      }).toThrow('PtyTerminal is not started or is destroyed');
     });
   });
 
@@ -273,11 +273,11 @@ describe('TUIAgent', () => {
 
   describe('Zombie Process Prevention', () => {
     it('should not create zombie processes with multiple agents', async () => {
-      const agents: TUIAgent[] = [];
+      const agents: PtyTerminal[] = [];
 
       // Create multiple agents
       for (let i = 0; i < 5; i++) {
-        const testAgent = new TUIAgent({}, processManager);
+        const testAgent = new PtyTerminal({}, processManager);
         await testAgent.start();
         agents.push(testAgent);
       }
@@ -300,11 +300,11 @@ describe('TUIAgent', () => {
     });
 
     it('should handle abrupt termination without zombies', async () => {
-      const agents: TUIAgent[] = [];
+      const agents: PtyTerminal[] = [];
 
       // Create agents and start long-running processes
       for (let i = 0; i < 3; i++) {
-        const testAgent = new TUIAgent({}, processManager);
+        const testAgent = new PtyTerminal({}, processManager);
         await testAgent.start();
         agents.push(testAgent);
 

--- a/src/__tests__/ZombieProcessPrevention.test.ts
+++ b/src/__tests__/ZombieProcessPrevention.test.ts
@@ -1,5 +1,5 @@
 import { ProcessLifecycleManager } from '../core/ProcessLifecycleManager';
-import { TUIAgent } from '../core/TUIAgent';
+import { PtyTerminal } from '../core/PtyTerminal';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -79,12 +79,12 @@ describe('Zombie Process Prevention Integration', () => {
 
   describe('TUI Agent Zombie Prevention', () => {
     it('should handle multiple TUI agents without zombies', async () => {
-      const agents: TUIAgent[] = [];
+      const agents: PtyTerminal[] = [];
       const agentCount = 10;
 
       // Create multiple TUI agents
       for (let i = 0; i < agentCount; i++) {
-        const agent = new TUIAgent({
+        const agent = new PtyTerminal({
           dimensions: { cols: 80, rows: 24 }
         }, processManager);
         await agent.start();
@@ -112,11 +112,11 @@ describe('Zombie Process Prevention Integration', () => {
     }, 20000);
 
     it('should handle agent failures without leaving zombies', async () => {
-      const agents: TUIAgent[] = [];
+      const agents: PtyTerminal[] = [];
 
       // Create agents
       for (let i = 0; i < 5; i++) {
-        const agent = new TUIAgent({}, processManager);
+        const agent = new PtyTerminal({}, processManager);
         await agent.start();
         agents.push(agent);
       }

--- a/src/adapters/scenarioAdapter.ts
+++ b/src/adapters/scenarioAdapter.ts
@@ -1,8 +1,8 @@
 /**
- * Adapter to convert between scenarios/TestScenario and models/OrchestratorScenario formats
+ * Adapter to convert between scenarios/ScenarioDefinition and models/OrchestratorScenario formats
  */
 
-import { TestScenario as SimpleScenario, TestStep as SimpleStep } from '../scenarios';
+import { ScenarioDefinition as SimpleScenario, TestStep as SimpleStep } from '../scenarios';
 import { OrchestratorScenario as ComplexScenario, OrchestratorStep, Priority, TestInterface } from '../models/TestModels';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/src/agents/APIAgent.ts
+++ b/src/agents/APIAgent.ts
@@ -13,7 +13,7 @@ import {
   TestStep, 
   TestStatus, 
   StepResult, 
-  TestScenario 
+  OrchestratorScenario
 } from '../models/TestModels';
 import { TestLogger, createLogger, LogLevel } from '../utils/logger';
 
@@ -282,7 +282,7 @@ export class APIAgent extends EventEmitter implements IAgent {
   /**
    * Execute a test scenario
    */
-  async execute(scenario: TestScenario): Promise<any> {
+  async execute(scenario: OrchestratorScenario): Promise<any> {
     if (!this.isInitialized) {
       throw new Error('Agent not initialized. Call initialize() first.');
     }

--- a/src/agents/ComprehensionAgent.ts
+++ b/src/agents/ComprehensionAgent.ts
@@ -11,7 +11,7 @@ import { glob } from 'glob';
 import OpenAI from 'openai';
 import { logger } from '../utils/logger';
 import { IAgent } from './index';
-import { TestScenario, TestStep, VerificationStep, Priority, TestInterface } from '../models/TestModels';
+import { OrchestratorScenario, TestStep, VerificationStep, Priority, TestInterface } from '../models/TestModels';
 
 /**
  * LLM provider types
@@ -510,10 +510,10 @@ Extract and return ONLY valid JSON in this exact format:
    * @param featureSpec - Feature specification
    * @returns List of test scenarios
    */
-  async generateTestScenarios(featureSpec: FeatureSpec): Promise<TestScenario[]> {
+  async generateTestScenarios(featureSpec: FeatureSpec): Promise<OrchestratorScenario[]> {
     logger.info(`Generating test scenarios for feature: ${featureSpec.name}`);
     
-    const scenarios: TestScenario[] = [];
+    const scenarios: OrchestratorScenario[] = [];
     let scenarioId = 1;
 
     // Generate success path scenario
@@ -542,7 +542,7 @@ Extract and return ONLY valid JSON in this exact format:
    * @param scenarioId - Scenario ID number
    * @returns Success test scenario
    */
-  private async generateSuccessScenario(spec: FeatureSpec, scenarioId: number): Promise<TestScenario> {
+  private async generateSuccessScenario(spec: FeatureSpec, scenarioId: number): Promise<OrchestratorScenario> {
     const id = `${spec.name.replace(/\s+/g, '_').toLowerCase()}_${scenarioId}`;
     
     return {
@@ -570,7 +570,7 @@ Extract and return ONLY valid JSON in this exact format:
    * @param scenarioId - Scenario ID number
    * @returns Failure test scenario
    */
-  private async generateFailureScenario(spec: FeatureSpec, failureMode: string, scenarioId: number): Promise<TestScenario> {
+  private async generateFailureScenario(spec: FeatureSpec, failureMode: string, scenarioId: number): Promise<OrchestratorScenario> {
     const id = `${spec.name.replace(/\s+/g, '_').toLowerCase()}_${scenarioId}`;
     
     return {
@@ -604,7 +604,7 @@ Extract and return ONLY valid JSON in this exact format:
    * @param scenarioId - Scenario ID number
    * @returns Edge case test scenario
    */
-  private async generateEdgeCaseScenario(spec: FeatureSpec, edgeCase: string, scenarioId: number): Promise<TestScenario> {
+  private async generateEdgeCaseScenario(spec: FeatureSpec, edgeCase: string, scenarioId: number): Promise<OrchestratorScenario> {
     const id = `${spec.name.replace(/\s+/g, '_').toLowerCase()}_${scenarioId}`;
     
     return {
@@ -808,12 +808,12 @@ Extract and return ONLY valid JSON in this exact format:
    * Process all discovered features and generate comprehensive test scenarios
    * @returns Comprehensive list of test scenarios
    */
-  async processDiscoveredFeatures(): Promise<TestScenario[]> {
+  async processDiscoveredFeatures(): Promise<OrchestratorScenario[]> {
     logger.info('Processing discovered features and generating test scenarios');
     
     try {
       const discoveredFeatures = await this.discoverFeatures();
-      const allScenarios: TestScenario[] = [];
+      const allScenarios: OrchestratorScenario[] = [];
 
       for (const feature of discoveredFeatures) {
         try {

--- a/src/agents/PriorityAgent.ts
+++ b/src/agents/PriorityAgent.ts
@@ -8,13 +8,13 @@
 
 import { EventEmitter } from 'events';
 import { IAgent, AgentType } from './index';
-import { 
-  TestFailure, 
-  TestResult, 
-  TestStatus, 
-  Priority, 
+import {
+  TestFailure,
+  TestResult,
+  TestStatus,
+  Priority,
   TestInterface,
-  TestScenario 
+  OrchestratorScenario
 } from '../models/TestModels';
 import { TestLogger, createLogger, LogLevel } from '../utils/logger';
 
@@ -79,7 +79,7 @@ export interface AnalysisContext {
   /** Historical test results */
   history: TestResult[];
   /** Test scenario information */
-  scenarios: Map<string, TestScenario>;
+  scenarios: Map<string, OrchestratorScenario>;
   /** Previous priority assignments */
   previousPriorities: Map<string, PriorityAssignment>;
   /** System metadata */
@@ -255,7 +255,7 @@ export class PriorityAgent extends EventEmitter implements IAgent {
   /**
    * Execute priority analysis on a scenario (implements IAgent interface)
    */
-  async execute(scenario: TestScenario): Promise<PriorityAssignment | null> {
+  async execute(scenario: OrchestratorScenario): Promise<PriorityAssignment | null> {
     if (!this.isInitialized) {
       throw new Error('PriorityAgent not initialized. Call initialize() first.');
     }

--- a/src/agents/WebSocketAgent.ts
+++ b/src/agents/WebSocketAgent.ts
@@ -10,11 +10,11 @@
 import { io, Socket } from 'socket.io-client';
 import { EventEmitter } from 'events';
 import { IAgent, AgentType } from './index';
-import { 
-  TestStep, 
-  TestStatus, 
-  StepResult, 
-  TestScenario 
+import {
+  TestStep,
+  TestStatus,
+  StepResult,
+  OrchestratorScenario
 } from '../models/TestModels';
 import { TestLogger, createLogger, LogLevel } from '../utils/logger';
 
@@ -274,7 +274,7 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
   /**
    * Execute a test scenario
    */
-  async execute(scenario: TestScenario): Promise<any> {
+  async execute(scenario: OrchestratorScenario): Promise<any> {
     if (!this.isInitialized) {
       throw new Error('Agent not initialized. Call initialize() first.');
     }

--- a/src/agents/examples/ElectronUIAgent.example.ts
+++ b/src/agents/examples/ElectronUIAgent.example.ts
@@ -6,7 +6,7 @@
  */
 
 import { ElectronUIAgent } from '../ElectronUIAgent';
-import { TestScenario, TestStep, Priority, TestInterface } from '../../models/TestModels';
+import { OrchestratorScenario, TestStep, Priority, TestInterface } from '../../models/TestModels';
 import { LogLevel } from '../../utils/logger';
 
 /**
@@ -88,7 +88,7 @@ async function fullScenarioTest(): Promise<void> {
   });
 
   // Define a complete test scenario
-  const scenario: TestScenario = {
+  const scenario: OrchestratorScenario = {
     id: 'spa-build-workflow',
     name: 'SPA Build Workflow Test',
     description: 'Complete workflow test for your application SPA',

--- a/src/agents/examples/PriorityAgent.example.ts
+++ b/src/agents/examples/PriorityAgent.example.ts
@@ -22,7 +22,7 @@ import {
   TestStatus,
   Priority,
   TestInterface,
-  TestScenario
+  OrchestratorScenario
 } from '../../models/TestModels';
 import { LogLevel } from '../../utils/logger';
 
@@ -352,7 +352,7 @@ export async function comprehensiveReportExample(): Promise<void> {
     await agent.initialize();
 
     // Create comprehensive test scenario
-    const scenarios = new Map<string, TestScenario>();
+    const scenarios = new Map<string, OrchestratorScenario>();
     scenarios.set('critical-login', {
       id: 'critical-login',
       name: 'User Login Flow',

--- a/src/core/PtyTerminal.ts
+++ b/src/core/PtyTerminal.ts
@@ -13,9 +13,9 @@ export interface TerminalDimensions {
 }
 
 /**
- * TUI Agent configuration
+ * PTY terminal configuration
  */
-export interface TUIAgentConfig {
+export interface PtyTerminalConfig {
   shell?: string;
   env?: NodeJS.ProcessEnv;
   cwd?: string;
@@ -24,9 +24,9 @@ export interface TUIAgentConfig {
 }
 
 /**
- * TUI Agent events
+ * PTY terminal events
  */
-export interface TUIAgentEvents {
+export interface PtyTerminalEvents {
   data: (data: string) => void;
   exit: (exitCode: number | null, signal: string | null) => void;
   error: (error: Error) => void;
@@ -35,22 +35,22 @@ export interface TUIAgentEvents {
 }
 
 /**
- * TUIAgent
+ * PtyTerminal
  *
- * Terminal User Interface Agent that manages terminal processes
+ * PTY-based terminal manager that manages terminal processes
  * with integrated ProcessLifecycleManager to prevent zombie processes.
  */
-export class TUIAgent extends EventEmitter {
+export class PtyTerminal extends EventEmitter {
   private ptyProcess: pty.IPty | null = null;
   private processInfo: ProcessInfo | null = null;
   private processManager: ProcessLifecycleManager;
-  private config: Required<TUIAgentConfig>;
+  private config: Required<PtyTerminalConfig>;
   private isDestroyed = false;
   private outputBuffer = '';
   private inputHistory: string[] = [];
 
   constructor(
-    config: TUIAgentConfig = {},
+    config: PtyTerminalConfig = {},
     processManager?: ProcessLifecycleManager
   ) {
     super();
@@ -102,11 +102,11 @@ export class TUIAgent extends EventEmitter {
    */
   public async start(): Promise<void> {
     if (this.isDestroyed) {
-      throw new Error('Cannot start a destroyed TUIAgent');
+      throw new Error('Cannot start a destroyed PtyTerminal');
     }
 
     if (this.ptyProcess) {
-      throw new Error('TUIAgent is already started');
+      throw new Error('PtyTerminal is already started');
     }
 
     try {
@@ -170,7 +170,7 @@ export class TUIAgent extends EventEmitter {
    */
   public write(data: string): void {
     if (!this.ptyProcess || this.isDestroyed) {
-      throw new Error('TUIAgent is not started or is destroyed');
+      throw new Error('PtyTerminal is not started or is destroyed');
     }
 
     this.ptyProcess.write(data);
@@ -195,7 +195,7 @@ export class TUIAgent extends EventEmitter {
     } = {}
   ): Promise<string> {
     if (!this.ptyProcess || this.isDestroyed) {
-      throw new Error('TUIAgent is not started or is destroyed');
+      throw new Error('PtyTerminal is not started or is destroyed');
     }
 
     const timeout = options.timeout || this.config.timeout;
@@ -267,7 +267,7 @@ export class TUIAgent extends EventEmitter {
    */
   public resize(dimensions: TerminalDimensions): void {
     if (!this.ptyProcess || this.isDestroyed) {
-      throw new Error('TUIAgent is not started or is destroyed');
+      throw new Error('PtyTerminal is not started or is destroyed');
     }
 
     this.ptyProcess.resize(dimensions.cols, dimensions.rows);

--- a/src/core/ResourceOptimizer.ts
+++ b/src/core/ResourceOptimizer.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { ProcessLifecycleManager } from './ProcessLifecycleManager';
-import { TUIAgent, TUIAgentConfig } from './TUIAgent';
+import { PtyTerminal, PtyTerminalConfig } from './PtyTerminal';
 
 /**
  * Resource pool configuration
@@ -60,8 +60,8 @@ interface PooledResource<T> {
  * Terminal connection pool entry
  */
 interface TerminalConnection {
-  agent: TUIAgent;
-  config: TUIAgentConfig;
+  agent: PtyTerminal;
+  config: PtyTerminalConfig;
 }
 
 /**
@@ -222,7 +222,7 @@ export class ResourceOptimizer extends EventEmitter {
   /**
    * Acquire a terminal connection from the pool
    */
-  public async acquireTerminal(config: TUIAgentConfig = {}): Promise<TUIAgent> {
+  public async acquireTerminal(config: PtyTerminalConfig = {}): Promise<PtyTerminal> {
     if (this.isDestroying) {
       throw new Error('ResourceOptimizer is being destroyed');
     }
@@ -261,7 +261,7 @@ export class ResourceOptimizer extends EventEmitter {
   /**
    * Release a terminal back to the pool
    */
-  public async releaseTerminal(agent: TUIAgent): Promise<void> {
+  public async releaseTerminal(agent: PtyTerminal): Promise<void> {
     const resource = this.findResourceByAgent(agent);
     if (!resource) {
       return; // Already released or not from pool
@@ -555,9 +555,9 @@ export class ResourceOptimizer extends EventEmitter {
   /**
    * Create a new terminal connection
    */
-  private async createTerminal(config: TUIAgentConfig): Promise<TUIAgent> {
+  private async createTerminal(config: PtyTerminalConfig): Promise<PtyTerminal> {
     const terminalId = this.generateId('terminal');
-    const agent = new TUIAgent(config, this.processManager);
+    const agent = new PtyTerminal(config, this.processManager);
 
     const pooledResource: PooledResource<TerminalConnection> = {
       id: terminalId,
@@ -586,7 +586,7 @@ export class ResourceOptimizer extends EventEmitter {
   /**
    * Wait for available terminal
    */
-  private async waitForTerminal(configKey: string, startTime: number): Promise<TUIAgent> {
+  private async waitForTerminal(configKey: string, startTime: number): Promise<PtyTerminal> {
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.removeFromWaitingQueue(configKey, resolve);
@@ -616,7 +616,7 @@ export class ResourceOptimizer extends EventEmitter {
   /**
    * Find resource by agent instance
    */
-  private findResourceByAgent(agent: TUIAgent): PooledResource<TerminalConnection> | null {
+  private findResourceByAgent(agent: PtyTerminal): PooledResource<TerminalConnection> | null {
     for (const resource of this.terminalPool.values()) {
       if (resource.resource.agent === agent) {
         return resource;
@@ -684,7 +684,7 @@ export class ResourceOptimizer extends EventEmitter {
   /**
    * Get configuration key for pooling
    */
-  private getConfigKey(config: TUIAgentConfig): string {
+  private getConfigKey(config: PtyTerminalConfig): string {
     return JSON.stringify({
       shell: config.shell,
       cwd: config.cwd,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 // Core exports
 export { ProcessLifecycleManager, processLifecycleManager } from './core/ProcessLifecycleManager';
-export { TUIAgent } from './core/TUIAgent';
+export { PtyTerminal } from './core/PtyTerminal';
+/** @deprecated Use PtyTerminal instead - renamed to resolve naming conflict with agents/TUIAgent */
+export { PtyTerminal as TUIAgent } from './core/PtyTerminal';
 export { ResourceOptimizer, resourceOptimizer } from './core/ResourceOptimizer';
 export {
   AdaptiveWaiter,
@@ -23,9 +25,14 @@ export type {
 
 export type {
   TerminalDimensions,
-  TUIAgentConfig,
-  TUIAgentEvents
-} from './core/TUIAgent';
+  PtyTerminalConfig,
+  PtyTerminalEvents
+} from './core/PtyTerminal';
+
+/** @deprecated Use PtyTerminalConfig instead */
+export type { PtyTerminalConfig as TUIAgentConfig } from './core/PtyTerminal';
+/** @deprecated Use PtyTerminalEvents instead */
+export type { PtyTerminalEvents as TUIAgentEvents } from './core/PtyTerminal';
 
 export type {
   ResourceOptimizerConfig,

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 // Import core modules
 import { TestOrchestrator, createTestOrchestrator } from './orchestrator';
 import { TestConfig, ExecutionConfig, CLIConfig, UIConfig, GitHubConfig, PriorityConfig, LoggingConfig, ReportingConfig, NotificationConfig } from './models/Config';
-import { TestSession, TestResult, TestScenario, TestInterface, TestStatus, TestSuite } from './models/TestModels';
+import { TestSession, TestResult, OrchestratorScenario, TestInterface, TestStatus, TestSuite } from './models/TestModels';
 import { logger, setupLogger, LogLevel } from './utils/logger';
 import { loadConfigFromYaml, loadConfigFromFile } from './utils/config';
 import { parseYamlScenarios } from './utils/yamlParser';
@@ -354,8 +354,8 @@ export async function loadConfiguration(configPath: string, cliArgs: CliArgument
 /**
  * Discover and load test scenarios
  */
-export async function loadTestScenarios(scenarioFiles?: string[]): Promise<TestScenario[]> {
-  const scenarios: TestScenario[] = [];
+export async function loadTestScenarios(scenarioFiles?: string[]): Promise<OrchestratorScenario[]> {
+  const scenarios: OrchestratorScenario[] = [];
   
   // Default scenario directory
   const scenarioDir = path.join(process.cwd(), 'scenarios');
@@ -401,7 +401,7 @@ export async function loadTestScenarios(scenarioFiles?: string[]): Promise<TestS
 /**
  * Filter scenarios based on test suite configuration
  */
-export function filterScenariosForSuite(scenarios: TestScenario[], suite: string): TestScenario[] {
+export function filterScenariosForSuite(scenarios: OrchestratorScenario[], suite: string): OrchestratorScenario[] {
   const suiteConfig = TEST_SUITES[suite];
   if (!suiteConfig) {
     logger.warn(`Unknown test suite: ${suite}, using all scenarios`);
@@ -414,7 +414,7 @@ export function filterScenariosForSuite(scenarios: TestScenario[], suite: string
     return scenarios;
   }
   
-  const filtered: TestScenario[] = [];
+  const filtered: OrchestratorScenario[] = [];
   
   for (const scenario of scenarios) {
     for (const pattern of patterns) {
@@ -495,7 +495,7 @@ export function displayResults(session: TestSession): void {
  * Perform dry run - discover and display scenarios without execution
  */
 export async function performDryRun(
-  scenarios: TestScenario[],
+  scenarios: OrchestratorScenario[],
   suite: string
 ): Promise<void> {
   const filteredScenarios = filterScenariosForSuite(scenarios, suite);
@@ -709,7 +709,7 @@ export {
   TestConfig,
   TestSession,
   TestResult,
-  TestScenario,
+  OrchestratorScenario,
   createTestOrchestrator
 };
 

--- a/src/models/TestModels.ts
+++ b/src/models/TestModels.ts
@@ -328,5 +328,5 @@ export interface TestAssertion {
 // Backward compatibility aliases
 /** @deprecated Use OrchestratorStep - kept for backward compatibility with existing code */
 export type TestStep = OrchestratorStep;
-/** @deprecated Use OrchestratorScenario - kept for backward compatibility with existing code */
-export type TestScenario = OrchestratorScenario;
+/** @deprecated Use OrchestratorScenario directly - this alias is removed to resolve naming conflict with scenarios/ScenarioDefinition */
+// export type TestScenario = OrchestratorScenario; // REMOVED: caused naming conflict with scenarios/index.ts TestScenario

--- a/src/orchestrator/TestOrchestrator.ts
+++ b/src/orchestrator/TestOrchestrator.ts
@@ -18,7 +18,7 @@ import {
   TestError,
   Priority
 } from '../models/TestModels';
-import { TestScenario } from '../scenarios';
+import { ScenarioDefinition } from '../scenarios';
 import {
   TestConfig,
   ExecutionConfig,
@@ -158,7 +158,7 @@ export class TestOrchestrator extends EventEmitter {
   /**
    * Run a complete testing session with pre-loaded scenarios
    */
-  async runWithScenarios(suite: string, loadedScenarios: TestScenario[]): Promise<TestSession> {
+  async runWithScenarios(suite: string, loadedScenarios: ScenarioDefinition[]): Promise<TestSession> {
     logger.info(`Starting test session with suite: ${suite}`);
 
     // Initialize agents before use

--- a/src/orchestrator/index.ts
+++ b/src/orchestrator/index.ts
@@ -11,9 +11,9 @@ export {
 } from './TestOrchestrator';
 
 // Re-export test models for convenience
-export type { 
+export type {
   TestSession,
   TestResult,
   TestFailure,
-  TestScenario 
+  OrchestratorScenario
 } from '../models/TestModels';

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 
 // Scenario loader utility
 export class ScenarioLoader {
-  static async loadFromFile(filePath: string): Promise<TestScenario> {
+  static async loadFromFile(filePath: string): Promise<ScenarioDefinition> {
     const content = await fs.readFile(filePath, 'utf-8');
     const raw = yaml.load(content) as any;
 
@@ -28,7 +28,7 @@ export class ScenarioLoader {
     }
   }
 
-  static async loadFromDirectory(dirPath: string): Promise<TestScenario[]> {
+  static async loadFromDirectory(dirPath: string): Promise<ScenarioDefinition[]> {
     const files = await fs.readdir(dirPath);
     const yamlFiles = files.filter(f => f.endsWith('.yaml') || f.endsWith('.yml'));
 
@@ -39,7 +39,7 @@ export class ScenarioLoader {
     return scenarios;
   }
 
-  private static convertLegacyFormat(raw: any): TestScenario {
+  private static convertLegacyFormat(raw: any): ScenarioDefinition {
     // Legacy format has application + scenarios array
     // Convert first scenario to new format (for now, only load first scenario)
     const firstScenario = raw.scenarios[0];
@@ -72,19 +72,19 @@ export class ScenarioLoader {
     };
   }
 
-  private static validateScenario(scenario: any): TestScenario {
+  private static validateScenario(scenario: any): ScenarioDefinition {
     if (!scenario.name) {
       throw new Error('Scenario must have a name');
     }
     if (!scenario.steps || !Array.isArray(scenario.steps)) {
       throw new Error('Scenario must have steps array');
     }
-    return scenario as TestScenario;
+    return scenario as ScenarioDefinition;
   }
 }
 
 // Scenario interfaces
-export interface TestScenario {
+export interface ScenarioDefinition {
   name: string;
   description?: string;
   version?: string;
@@ -96,6 +96,9 @@ export interface TestScenario {
   cleanup?: TestStep[];
   metadata?: ScenarioMetadata;
 }
+
+/** @deprecated Use ScenarioDefinition instead - renamed to resolve naming conflict with models/TestModels.TestScenario */
+export type TestScenario = ScenarioDefinition;
 
 export interface ScenarioConfig {
   timeout?: number;

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -6,7 +6,7 @@
 import * as yaml from 'js-yaml';
 import fs from 'fs/promises';
 import path from 'path';
-import { TestScenario, TestStep, VerificationStep, Priority, TestInterface } from '../models/TestModels';
+import { OrchestratorScenario, TestStep, VerificationStep, Priority, TestInterface } from '../models/TestModels';
 
 /**
  * YAML parsing error class
@@ -111,7 +111,7 @@ export class YamlParser {
   /**
    * Load and parse a YAML file containing test scenarios
    */
-  async loadScenarios(filePath: string, variables: VariableContext = this.createDefaultVariableContext()): Promise<TestScenario[]> {
+  async loadScenarios(filePath: string, variables: VariableContext = this.createDefaultVariableContext()): Promise<OrchestratorScenario[]> {
     try {
       const absolutePath = path.resolve(this.config.baseDir, filePath);
       const content = await fs.readFile(absolutePath, 'utf-8');
@@ -149,7 +149,7 @@ export class YamlParser {
   /**
    * Load a single scenario from YAML string
    */
-  parseScenario(yamlContent: string, variables: VariableContext = this.createDefaultVariableContext()): TestScenario {
+  parseScenario(yamlContent: string, variables: VariableContext = this.createDefaultVariableContext()): OrchestratorScenario {
     try {
       const parsed = yaml.load(yamlContent) as RawScenario;
       if (!parsed) {
@@ -294,9 +294,9 @@ export class YamlParser {
   }
 
   /**
-   * Validate and convert raw scenario to TestScenario
+   * Validate and convert raw scenario to OrchestratorScenario
    */
-  private validateAndConvertScenario(raw: RawScenario, context: string): TestScenario {
+  private validateAndConvertScenario(raw: RawScenario, context: string): OrchestratorScenario {
     const errors: string[] = [];
 
     // Required fields
@@ -468,9 +468,9 @@ export class YamlParser {
   }
 
   /**
-   * Convert TestScenario back to YAML string
+   * Convert OrchestratorScenario back to YAML string
    */
-  scenarioToYaml(scenario: TestScenario): string {
+  scenarioToYaml(scenario: OrchestratorScenario): string {
     const yamlObject = {
       id: scenario.id,
       name: scenario.name,
@@ -514,7 +514,7 @@ export function createYamlParser(config?: Partial<YamlParserConfig>): YamlParser
 /**
  * Convenience function to load scenarios from a file
  */
-export async function loadScenariosFromFile(filePath: string, variables?: VariableContext): Promise<TestScenario[]> {
+export async function loadScenariosFromFile(filePath: string, variables?: VariableContext): Promise<OrchestratorScenario[]> {
   const parser = createYamlParser();
   return parser.loadScenarios(filePath, variables);
 }
@@ -522,7 +522,7 @@ export async function loadScenariosFromFile(filePath: string, variables?: Variab
 /**
  * Convenience function to parse a scenario from YAML string
  */
-export function parseScenarioFromYaml(yamlContent: string, variables?: VariableContext): TestScenario {
+export function parseScenarioFromYaml(yamlContent: string, variables?: VariableContext): OrchestratorScenario {
   const parser = createYamlParser();
   return parser.parseScenario(yamlContent, variables);
 }


### PR DESCRIPTION
## Summary

Resolves #14 and #25 — Duplicate incompatible type systems and TUIAgent naming collision.

### Part A: TUIAgent → PtyTerminal rename
- Renamed `src/core/TUIAgent.ts` → `src/core/PtyTerminal.ts`
- Class `TUIAgent` → `PtyTerminal`, `TUIAgentConfig` → `PtyTerminalConfig`, `TUIAgentEvents` → `PtyTerminalEvents`
- Updated `src/index.ts` with new exports and backward-compatible deprecated aliases
- Updated all test imports (`TUIAgent.test.ts`, `ResourceOptimizer.test.ts`, `ZombieProcessPrevention.test.ts`)

### Part B: TestScenario type conflict resolution
- Renamed `scenarios/index.ts` `TestScenario` → `ScenarioDefinition` (the YAML-facing type)
- Added deprecated `TestScenario` alias for backward compatibility
- Updated `scenarioAdapter.ts` to import `ScenarioDefinition`
- Removed confusing `TestScenario` alias from `models/TestModels.ts`

## Key Changes

| Before | After |
|--------|-------|
| Two `TUIAgent` classes with same name | `PtyTerminal` (core) vs `TUIAgent` (agents) |
| Two `TUIAgentConfig` types with same name | `PtyTerminalConfig` (core) vs `TUIAgentConfig` (agents) |
| Two incompatible `TestScenario` types | `ScenarioDefinition` (YAML) vs `OrchestratorScenario` (models) |

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit --skipLibCheck`)
- [x] All 104 tests pass (1 pre-existing skip)
- [x] No file exports `class TUIAgent` from `src/core/`
- [x] No two types named `TestScenario` with different shapes
- [x] Backward-compatible deprecated aliases preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)