### PR TITLE
fix: enforce IAgent contract, remove stubs, extract shared utilities (#29)

### DIFF
--- a/src/adapters/scenarioAdapter.ts
+++ b/src/adapters/scenarioAdapter.ts
@@ -48,12 +48,6 @@ export function adaptScenarioToComplex(simple: SimpleScenario): ComplexScenario 
 }
 
 /**
- * Session ID tracker for multi-step scenarios
- * The first spawn action creates a session, subsequent steps reference it
- */
-let lastSessionId: string | null = null;
-
-/**
  * Convert scenarios/TestStep to models/OrchestratorStep
  */
 function adaptStepToOrchestrator(simpleStep: SimpleStep, stepIndex: number): OrchestratorStep {
@@ -69,10 +63,6 @@ function adaptStepToOrchestrator(simpleStep: SimpleStep, stepIndex: number): Orc
       target = `${params.command} ${params.args.join(' ')}`;
     } else {
       target = params.command;
-    }
-    // First spawn step establishes the session
-    if (stepIndex === 0) {
-      lastSessionId = null; // Reset for new scenario
     }
   } else if (params.text !== undefined || params.duration !== undefined) {
     // For actions that operate on the spawned session

--- a/src/agents/ComprehensionAgent.ts
+++ b/src/agents/ComprehensionAgent.ts
@@ -10,7 +10,7 @@ import { join, relative } from 'path';
 import { glob } from 'glob';
 import OpenAI from 'openai';
 import { logger } from '../utils/logger';
-import { IAgent } from './index';
+import { IAgent, AgentType } from './index';
 import { OrchestratorScenario, TestStep, VerificationStep, Priority, TestInterface } from '../models/TestModels';
 
 /**
@@ -286,7 +286,7 @@ export class DocumentationLoader {
  */
 export class ComprehensionAgent implements IAgent {
   name = 'ComprehensionAgent';
-  type = 'comprehension';
+  type = AgentType.COMPREHENSION;
 
   private config: ComprehensionAgentConfig;
   private docLoader: DocumentationLoader;

--- a/src/agents/IssueReporter.ts
+++ b/src/agents/IssueReporter.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { TestFailure, TestResult, TestError } from '../models/TestModels';
 import { GitHubConfig } from '../models/Config';
 import { TestLogger, logger } from '../utils/logger';
-import { IAgent, AgentType } from './index';
+import { AgentType } from './index';
 
 /**
  * GitHub API rate limit information
@@ -200,7 +200,7 @@ const DEFAULT_CONFIG: Partial<IssueReporterConfig> = {
  * and issue management with advanced features like deduplication,
  * template-based issue creation, and rate limiting.
  */
-export class IssueReporter implements IAgent {
+export class IssueReporter {
   public readonly name = 'IssueReporter';
   public readonly type = AgentType.GITHUB;
 
@@ -252,13 +252,6 @@ export class IssueReporter implements IAgent {
       this.logger.error('Failed to initialize IssueReporter', { error: (error as Error).message });
       throw error;
     }
-  }
-
-  /**
-   * Execute scenario (not applicable for this agent)
-   */
-  async execute(scenario: any): Promise<any> {
-    throw new Error('IssueReporter does not support direct scenario execution');
   }
 
   /**

--- a/src/agents/PriorityAgent.ts
+++ b/src/agents/PriorityAgent.ts
@@ -212,7 +212,7 @@ const DEFAULT_CONFIG: Required<PriorityAgentConfig> = {
  */
 export class PriorityAgent extends EventEmitter implements IAgent {
   public readonly name = 'PriorityAgent';
-  public readonly type = AgentType.SYSTEM;
+  public readonly type = AgentType.PRIORITY;
 
   private config: Required<PriorityAgentConfig>;
   private logger: TestLogger;

--- a/src/agents/TUIAgent.ts
+++ b/src/agents/TUIAgent.ts
@@ -23,6 +23,7 @@ import {
   CommandResult
 } from '../models/TestModels';
 import { TestLogger, createLogger, LogLevel } from '../utils/logger';
+import { delay } from '../utils/async';
 
 /**
  * TUI Agent configuration options
@@ -266,7 +267,7 @@ const DEFAULT_CONFIG: Required<TUIAgentConfig> = {
  */
 export class TUIAgent extends EventEmitter implements IAgent {
   public readonly name = 'TUIAgent';
-  public readonly type = AgentType.SYSTEM;
+  public readonly type = AgentType.TUI;
 
   private config: Required<TUIAgentConfig>;
   private logger: TestLogger;
@@ -480,13 +481,13 @@ export class TUIAgent extends EventEmitter implements IAgent {
         if (session.process.stdin) {
           session.process.stdin.write(char);
           if (timing > 0) {
-            await this.delay(timing);
+            await delay(timing);
           }
         }
       }
 
       // Wait for response delay
-      await this.delay(this.config.inputTiming.responseDelay);
+      await delay(this.config.inputTiming.responseDelay);
 
       // Wait for output stabilization if requested
       if (waitForStabilization) {
@@ -654,7 +655,7 @@ export class TUIAgent extends EventEmitter implements IAgent {
         session.process.kill('SIGTERM');
 
         // Wait for graceful shutdown
-        await this.delay(1000);
+        await delay(1000);
 
         // Force kill if still running
         if (!session.process.killed) {
@@ -754,7 +755,7 @@ export class TUIAgent extends EventEmitter implements IAgent {
 
         case 'wait':
           const waitTime = parseInt(step.value || '1000');
-          await this.delay(waitTime);
+          await delay(waitTime);
           result = `Waited ${waitTime}ms`;
           break;
 
@@ -998,7 +999,7 @@ export class TUIAgent extends EventEmitter implements IAgent {
 
     for (let i = 0; i < count; i++) {
       await this.sendInput(sessionId, this.getKeyMapping(key));
-      await this.delay(this.config.inputTiming.keystrokeDelay);
+      await delay(this.config.inputTiming.keystrokeDelay);
     }
 
     this.menuContext.selectedIndex = targetIndex;
@@ -1207,10 +1208,6 @@ export class TUIAgent extends EventEmitter implements IAgent {
       ...safeConfig,
       environment: environment ? Object.keys(environment) : undefined
     };
-  }
-
-  private async delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   // Step action handlers

--- a/src/agents/WebSocketAgent.ts
+++ b/src/agents/WebSocketAgent.ts
@@ -17,6 +17,8 @@ import {
   OrchestratorScenario
 } from '../models/TestModels';
 import { TestLogger, createLogger, LogLevel } from '../utils/logger';
+import { delay } from '../utils/async';
+import { deepEqual } from '../utils/comparison';
 
 /**
  * WebSocket connection states
@@ -582,7 +584,7 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
           
         case 'wait':
           const waitTime = parseInt(step.value || '1000');
-          await this.delay(waitTime);
+          await delay(waitTime);
           result = true;
           break;
           
@@ -916,7 +918,7 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
 
     try {
       const expectedData = JSON.parse(expected);
-      return this.deepEqual(latestMessage.data, expectedData);
+      return deepEqual(latestMessage.data, expectedData);
     } catch {
       // If not JSON, do string comparison
       return JSON.stringify(latestMessage.data).includes(expected);
@@ -1074,8 +1076,7 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
   }
 
   private getScenarioLogs(): string[] {
-    // Return recent logs related to the current scenario
-    return [];
+    return this.logger ? ['No scenario-specific logs available'] : [];
   }
 
   private setupEventListeners(): void {
@@ -1084,31 +1085,6 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
     });
   }
 
-  private deepEqual(obj1: any, obj2: any): boolean {
-    if (obj1 === obj2) return true;
-    
-    if (obj1 == null || obj2 == null) return false;
-    
-    if (typeof obj1 !== typeof obj2) return false;
-    
-    if (typeof obj1 !== 'object') return obj1 === obj2;
-    
-    const keys1 = Object.keys(obj1);
-    const keys2 = Object.keys(obj2);
-    
-    if (keys1.length !== keys2.length) return false;
-    
-    for (const key of keys1) {
-      if (!keys2.includes(key)) return false;
-      if (!this.deepEqual(obj1[key], obj2[key])) return false;
-    }
-    
-    return true;
-  }
-
-  private async delay(ms: number): Promise<void> {
-    return new Promise(resolve => setTimeout(resolve, ms));
-  }
 }
 
 /**

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -3,11 +3,11 @@
  */
 
 // Base agent interface
-export interface IAgent {
+export interface IAgent<TScenario = unknown, TResult = unknown> {
   name: string;
   type: string;
   initialize(): Promise<void>;
-  execute(scenario: any): Promise<any>;
+  execute(scenario: TScenario): Promise<TResult>;
   cleanup(): Promise<void>;
 }
 
@@ -20,7 +20,8 @@ export enum AgentType {
   WEBSOCKET = 'websocket',
   GITHUB = 'github',
   SYSTEM = 'system',
-  COMPREHENSION = 'comprehension'
+  COMPREHENSION = 'comprehension',
+  PRIORITY = 'priority'
 }
 
 // Re-export all agent implementations

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,0 +1,6 @@
+/**
+ * Async utility functions shared across agents
+ */
+
+export const delay = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));

--- a/src/utils/comparison.ts
+++ b/src/utils/comparison.ts
@@ -1,0 +1,16 @@
+/**
+ * Comparison utility functions shared across agents
+ */
+
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== 'object') return false;
+  const aKeys = Object.keys(a as Record<string, unknown>);
+  const bKeys = Object.keys(b as Record<string, unknown>);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every(key =>
+    deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,8 @@ export * from './config';
 export * from './retry';
 export * from './screenshot';
 export * from './fileUtils';
+export * from './async';
+export * from './comparison';
 
 // Legacy exports for backward compatibility
 import winston from 'winston';


### PR DESCRIPTION
## Summary

Resolves #29 — IssueReporter.execute() always throws, plus 5 other stub methods.

### Changes

**IAgent interface** (`src/agents/index.ts`):
- Made generic: `IAgent<TScenario = unknown, TResult = unknown>`
- Added `PRIORITY = 'priority'` to AgentType enum

**IssueReporter** (`src/agents/IssueReporter.ts`):
- Removed `implements IAgent` — IssueReporter is not an execution agent
- Removed the `execute()` method that always threw

**AgentType fixes**:
- `TUIAgent`: `AgentType.SYSTEM` → `AgentType.TUI`
- `PriorityAgent`: `AgentType.SYSTEM` → `AgentType.PRIORITY`
- `ComprehensionAgent`: string literal `'comprehension'` → `AgentType.COMPREHENSION`

**Shared utility extraction**:
- New `src/utils/async.ts`: `delay()` (was duplicated in 4 agent files)
- New `src/utils/comparison.ts`: `deepEqual()` (was duplicated in 3 agent files)
- Removed private `delay()` from APIAgent, WebSocketAgent, CLIAgent, TUIAgent
- Removed private `deepEqual()` from APIAgent, WebSocketAgent, CLIAgent

**Dead code removal**:
- Removed `lastSessionId` module-level mutable variable from `scenarioAdapter.ts`
- Removed `validateResponseSchema()` stub from APIAgent (always returned true)
- Updated `getScenarioLogs()` in WebSocketAgent/APIAgent to be informative

**Net: -128 lines of duplicated/dead code**

## Test plan

- [x] TypeScript compilation passes
- [x] All 104 tests pass (1 pre-existing skip)
- [x] `delay()` and `deepEqual()` exist exactly once each (in utils)
- [x] No agent has `type = AgentType.SYSTEM` unless it IS SystemAgent
- [x] IssueReporter does not implement IAgent
- [x] No `lastSessionId` in scenarioAdapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)