### PR TITLE
fix: replace octal escapes \033 with \x1b in terminal.integration.test.ts (#38)

### DIFF
--- a/tests/terminal.integration.test.ts
+++ b/tests/terminal.integration.test.ts
@@ -708,8 +708,8 @@ echo -e "\nComplete!"
       const cursorScript = path.join(tempDir, 'cursor.sh');
       await fs.writeFile(cursorScript, `#!/bin/bash
 echo -e "Line 1\nLine 2\nLine 3"
-echo -e "\033[2A\033[10GModified"
-echo -e "\033[2B"
+echo -e "\x1b[2A\x1b[10GModified"
+echo -e "\x1b[2B"
 echo "Done"
 `, { mode: 0o755 });
 
@@ -717,7 +717,7 @@ echo "Done"
       await new Promise(resolve => setTimeout(resolve, 500));
 
       const output = agent.captureOutput(sessionId);
-      expect(output?.raw).toContain('\033['); // Should contain escape sequences
+      expect(output?.raw).toContain('\x1b['); // Should contain escape sequences
       expect(output?.text).toContain('Modified');
       expect(output?.text).toContain('Done');
     });


### PR DESCRIPTION
## Summary

Fixes #38

- Replace all `\033` octal escape sequences with `\x1b` hex equivalents on lines 711, 712, and 720 of `tests/terminal.integration.test.ts`
- TypeScript strict mode (TS1487) disallows octal escape sequences in strings
- The two forms are semantically identical — `\033` and `\x1b` both represent ESC (ASCII 27)

## Changes

`tests/terminal.integration.test.ts`:
- Line 711: `"\033[2A\033[10GModified"` → `"\x1b[2A\x1b[10GModified"`
- Line 712: `"\033[2B"` → `"\x1b[2B"`
- Line 720: `'\033['` → `'\x1b['`

## Test plan

- [x] Run `npx jest tests/terminal.integration.test.ts --no-coverage` — all 27 tests pass
- [x] Confirm no remaining `\033` sequences: `grep -n '\\033' tests/terminal.integration.test.ts` returns no output
- [x] TypeScript compilation errors (TS1487) resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)