### PR TITLE
fix: add exec to child_process mock in TUIAgent.test.ts (#37)

### DIFF
--- a/tests/TUIAgent.test.ts
+++ b/tests/TUIAgent.test.ts
@@ -20,9 +20,13 @@ import { spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-// Mock child_process for controlled testing
+// Mock child_process for controlled testing.
+// exec must be included because DockerMonitor.ts calls promisify(exec) at
+// module load time (line 12). Without exec in the mock, promisify receives
+// undefined and throws immediately when the module is imported. (#37)
 jest.mock('child_process', () => ({
-  spawn: jest.fn()
+  spawn: jest.fn(),
+  exec: jest.fn()
 }));
 
 describe('TUIAgent', () => {


### PR DESCRIPTION
## Summary

- `DockerMonitor.ts` (introduced in PR #36) calls `promisify(exec)` at module load time (line 12), where `exec` is imported directly from `child_process`
- `tests/TUIAgent.test.ts` mocked `child_process` with only `spawn`, leaving `exec` as `undefined`
- `promisify(undefined)` throws immediately when the module is imported, failing the entire test suite
- This PR adds `exec: jest.fn()` to the mock factory to resolve the import-time error

Fixes #37.

## Test plan

- [x] Ran `npx jest tests/TUIAgent.test.ts -t "Initialization" --no-coverage --forceExit` — 8 tests pass, 0 failures, no module-load errors
- [x] Ran `npx jest src/agents/__tests__/ComprehensionAgent.test.ts --no-coverage --forceExit` — 17 tests pass, no regressions
- [x] The fix is minimal and surgical: one additional mock entry, with an inline comment explaining why `exec` must be mocked alongside `spawn`

## Change

```diff
-// Mock child_process for controlled testing
+// Mock child_process for controlled testing.
+// exec must be included because DockerMonitor.ts calls promisify(exec) at
+// module load time (line 12). Without exec in the mock, promisify receives
+// undefined and throws immediately when the module is imported. (#37)
 jest.mock('child_process', () => ({
-  spawn: jest.fn()
+  spawn: jest.fn(),
+  exec: jest.fn()
 }));
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)