### PR TITLE
fix: reduce 'any' type usages from 175 to 140 (#55)

### DIFF
--- a/src/agents/system/types.ts
+++ b/src/agents/system/types.ts
@@ -184,7 +184,7 @@ export interface SystemIssue {
   type: 'cpu' | 'memory' | 'disk' | 'process' | 'network' | 'docker';
   severity: 'low' | 'medium' | 'high' | 'critical';
   message: string;
-  details: any;
+  details: unknown;
   timestamp: Date;
 }
 
@@ -207,7 +207,7 @@ export interface PerformanceIssue {
   component: string;
   impact: 'low' | 'medium' | 'high';
   duration: number;
-  details: any;
+  details: unknown;
 }
 
 /**

--- a/src/core/AdaptiveWaiter.ts
+++ b/src/core/AdaptiveWaiter.ts
@@ -272,7 +272,7 @@ export class AdaptiveWaiter {
   public async waitForAny(
     conditions: WaitCondition[],
     options: WaitOptions = {}
-  ): Promise<WaitResult<any>> {
+  ): Promise<WaitResult<unknown>> {
     return this.waitForCondition(async () => {
       for (let i = 0; i < conditions.length; i++) {
         try {

--- a/src/models/TUIModels.ts
+++ b/src/models/TUIModels.ts
@@ -304,7 +304,7 @@ export interface TUIStyleAssertion {
 export interface TUIScreenAssertion {
   type: TUIScreenAssertionType;
   /** Expected value */
-  expected: any;
+  expected: unknown;
   /** Description of assertion */
   description?: string;
 }
@@ -522,8 +522,8 @@ export interface TUITestResult {
       type: TUIVerificationType;
       passed: boolean;
       message: string;
-      expected?: any;
-      actual?: any;
+      expected?: unknown;
+      actual?: unknown;
     }[];
     /** Performance metrics */
     performance: {

--- a/src/models/TestModels.ts
+++ b/src/models/TestModels.ts
@@ -278,7 +278,7 @@ export interface TestSession {
     skipped: number;
   };
   /** Configuration used */
-  config?: any;
+  config?: unknown;
   /** Number of scenarios executed */
   scenariosExecuted?: number;
   /** Number of issues created from failures */
@@ -320,8 +320,8 @@ export enum AssertionType {
 
 export interface TestAssertion {
   type: AssertionType;
-  value: any;
-  expected?: any;
+  value: unknown;
+  expected?: unknown;
   operator?: 'equals' | 'contains' | 'exists' | 'gt' | 'lt' | 'gte' | 'lte';
 }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -214,8 +214,8 @@ export class ConfigManager {
       const fileContent = await fs.readFile(absolutePath, 'utf-8');
       const extension = path.extname(absolutePath).toLowerCase();
 
-      let fileConfig: any;
-      
+      let fileConfig: unknown;
+
       if (extension === '.json') {
         fileConfig = JSON.parse(fileContent);
       } else if (extension === '.yaml' || extension === '.yml') {
@@ -225,13 +225,13 @@ export class ConfigManager {
       }
 
       // Validate the loaded configuration
-      const validation = this.validateConfig(fileConfig);
+      const validation = this.validateConfig(fileConfig as Partial<TestConfig>);
       if (!validation.valid) {
         throw new ConfigError(`Configuration validation failed: ${validation.errors.join(', ')}`, filePath);
       }
 
       // Merge with existing config
-      this.config = this.mergeConfigs(this.config, fileConfig);
+      this.config = this.mergeConfigs(this.config, fileConfig as Partial<TestConfig>);
       this.metadata = {
         source: ConfigSource.FILE,
         loadedAt: new Date(),
@@ -254,7 +254,7 @@ export class ConfigManager {
    * Load configuration from environment variables
    */
   loadFromEnvironment(): void {
-    const envConfig: any = {};
+    const envConfig: Record<string, unknown> = {};
 
     Object.entries(ENV_MAPPINGS).forEach(([envVar, configPath]) => {
       const envValue = process.env[envVar];
@@ -316,13 +316,13 @@ export class ConfigManager {
    * Get a specific configuration value by path
    */
   get<T = any>(path: string, defaultValue?: T): T {
-    return this.getNestedValue(this.config, path) ?? defaultValue;
+    return (this.getNestedValue(this.config, path) ?? defaultValue) as T;
   }
 
   /**
    * Set a specific configuration value by path
    */
-  set(path: string, value: any): void {
+  set(path: string, value: unknown): void {
     const updates = {};
     this.setNestedValue(updates, path, value);
     this.updateConfig(updates);
@@ -346,7 +346,7 @@ export class ConfigManager {
   /**
    * Validate configuration object
    */
-  validateConfig(config: any): ValidationResult {
+  validateConfig(config: Partial<TestConfig>): ValidationResult {
     const errors: string[] = [];
     const warnings: string[] = [];
 
@@ -513,14 +513,14 @@ export class ConfigManager {
   /**
    * Get nested value from object using dot notation
    */
-  private getNestedValue(obj: any, path: string): any {
+  private getNestedValue(obj: Record<string, any>, path: string): unknown {
     return path.split('.').reduce((current, key) => current?.[key], obj);
   }
 
   /**
    * Set nested value in object using dot notation
    */
-  private setNestedValue(obj: any, path: string, value: any): void {
+  private setNestedValue(obj: Record<string, any>, path: string, value: unknown): void {
     const keys = path.split('.');
     const lastKey = keys.pop()!;
     
@@ -537,7 +537,7 @@ export class ConfigManager {
   /**
    * Parse environment variable value to appropriate type
    */
-  private parseEnvValue(value: string): any {
+  private parseEnvValue(value: string): unknown {
     // Boolean values
     if (value.toLowerCase() === 'true') return true;
     if (value.toLowerCase() === 'false') return false;

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -135,7 +135,7 @@ export class FileUtils {
   /**
    * Read a JSON file and parse it
    */
-  static async readJsonFile<T = any>(filePath: string): Promise<T> {
+  static async readJsonFile<T = unknown>(filePath: string): Promise<T> {
     try {
       const content = await fs.readFile(filePath, 'utf-8');
       return JSON.parse(content) as T;
@@ -151,7 +151,7 @@ export class FileUtils {
   /**
    * Write an object to a JSON file
    */
-  static async writeJsonFile(filePath: string, data: any, pretty: boolean = true): Promise<void> {
+  static async writeJsonFile(filePath: string, data: unknown, pretty: boolean = true): Promise<void> {
     try {
       await this.ensureDirectory(path.dirname(filePath));
       const content = pretty ? JSON.stringify(data, null, 2) : JSON.stringify(data);
@@ -733,14 +733,14 @@ export async function ensureDir(dirPath: string): Promise<void> {
 /**
  * Read JSON file
  */
-export async function readJson<T = any>(filePath: string): Promise<T> {
+export async function readJson<T = unknown>(filePath: string): Promise<T> {
   return FileUtils.readJsonFile<T>(filePath);
 }
 
 /**
  * Write JSON file
  */
-export async function writeJson(filePath: string, data: any, pretty: boolean = true): Promise<void> {
+export async function writeJson(filePath: string, data: unknown, pretty: boolean = true): Promise<void> {
   return FileUtils.writeJsonFile(filePath, data, pretty);
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -40,14 +40,14 @@ export const legacyLogger = createLegacyLogger(process.env.LOG_LEVEL || 'info');
 
 // Legacy configuration utilities (kept for backward compatibility)
 export class LegacyConfigManager {
-  private static config: Record<string, any> = {};
-  
-  static set(key: string, value: any): void {
+  private static config: Record<string, unknown> = {};
+
+  static set(key: string, value: unknown): void {
     this.config[key] = value;
   }
-  
-  static get<T = any>(key: string, defaultValue?: T): T {
-    return this.config[key] ?? defaultValue;
+
+  static get<T = unknown>(key: string, defaultValue?: T): T {
+    return (this.config[key] ?? defaultValue) as T;
   }
   
   static has(key: string): boolean {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -31,7 +31,7 @@ export interface LogContext {
   /** Session or run ID */
   sessionId?: string;
   /** Additional metadata */
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 /**
@@ -216,36 +216,36 @@ export class TestLogger {
   /**
    * Log an error message
    */
-  error(message: string, meta?: any): void {
-    this.logger.error(message, { ...this.context, ...meta });
+  error(message: string, meta?: unknown): void {
+    this.logger.error(message, { ...this.context, ...(typeof meta === 'object' && meta !== null ? meta as Record<string, unknown> : { meta }) });
   }
 
   /**
    * Log a warning message
    */
-  warn(message: string, meta?: any): void {
-    this.logger.warn(message, { ...this.context, ...meta });
+  warn(message: string, meta?: unknown): void {
+    this.logger.warn(message, { ...this.context, ...(typeof meta === 'object' && meta !== null ? meta as Record<string, unknown> : { meta }) });
   }
 
   /**
    * Log an info message
    */
-  info(message: string, meta?: any): void {
-    this.logger.info(message, { ...this.context, ...meta });
+  info(message: string, meta?: unknown): void {
+    this.logger.info(message, { ...this.context, ...(typeof meta === 'object' && meta !== null ? meta as Record<string, unknown> : { meta }) });
   }
 
   /**
    * Log an HTTP message
    */
-  http(message: string, meta?: any): void {
-    this.logger.http(message, { ...this.context, ...meta });
+  http(message: string, meta?: unknown): void {
+    this.logger.http(message, { ...this.context, ...(typeof meta === 'object' && meta !== null ? meta as Record<string, unknown> : { meta }) });
   }
 
   /**
    * Log a debug message
    */
-  debug(message: string, meta?: any): void {
-    this.logger.debug(message, { ...this.context, ...meta });
+  debug(message: string, meta?: unknown): void {
+    this.logger.debug(message, { ...this.context, ...(typeof meta === 'object' && meta !== null ? meta as Record<string, unknown> : { meta }) });
   }
 
   /**
@@ -300,7 +300,7 @@ export class TestLogger {
   /**
    * Log performance metrics
    */
-  performance(operation: string, duration: number, metadata?: Record<string, any>): void {
+  performance(operation: string, duration: number, metadata?: Record<string, unknown>): void {
     this.info(`Performance: ${operation} took ${duration}ms`, {
       event: 'performance',
       operation,
@@ -429,10 +429,10 @@ export const defaultLogger = _activeLogger;
  * Safe to use before or after setupLogger() is called.
  */
 export const logger = {
-  error: (message: string, meta?: any) => _activeLogger.error(message, meta),
-  warn: (message: string, meta?: any) => _activeLogger.warn(message, meta),
-  info: (message: string, meta?: any) => _activeLogger.info(message, meta),
-  debug: (message: string, meta?: any) => _activeLogger.debug(message, meta),
+  error: (message: string, meta?: unknown) => _activeLogger.error(message, meta),
+  warn: (message: string, meta?: unknown) => _activeLogger.warn(message, meta),
+  info: (message: string, meta?: unknown) => _activeLogger.info(message, meta),
+  debug: (message: string, meta?: unknown) => _activeLogger.debug(message, meta),
   setContext: (context: LogContext) => _activeLogger.setContext(context),
   clearContext: () => _activeLogger.clearContext(),
   setLevel: (level: LogLevel) => _activeLogger.setLevel(level),

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -22,7 +22,7 @@ export class YamlParseError extends Error {
  * Validation error class
  */
 export class ValidationError extends Error {
-  constructor(message: string, public field?: string, public value?: any) {
+  constructor(message: string, public field?: string, public value?: unknown) {
     super(message);
     this.name = 'ValidationError';
   }
@@ -35,9 +35,9 @@ export interface VariableContext {
   /** Environment variables */
   env: Record<string, string>;
   /** Global variables */
-  global: Record<string, any>;
+  global: Record<string, unknown>;
   /** Scenario-specific variables */
-  scenario: Record<string, any>;
+  scenario: Record<string, unknown>;
 }
 
 /**
@@ -58,15 +58,15 @@ interface RawScenario {
   priority?: string;
   interface?: string;
   prerequisites?: string[];
-  steps?: any[];
-  verifications?: any[];
+  steps?: unknown[];
+  verifications?: unknown[];
   expectedOutcome?: string;
   estimatedDuration?: number;
   tags?: string[];
   enabled?: boolean;
   environment?: Record<string, string>;
-  cleanup?: any[];
-  variables?: Record<string, any>;
+  cleanup?: unknown[];
+  variables?: Record<string, unknown>;
   includes?: string[];
 }
 
@@ -81,7 +81,7 @@ export interface YamlParserConfig {
   /** Whether to validate schemas strictly */
   strictValidation: boolean;
   /** Custom variable resolvers */
-  variableResolvers: Record<string, (value: any) => any>;
+  variableResolvers: Record<string, (value: unknown) => unknown>;
   /** Default environment variables */
   defaultEnvironment: Record<string, string>;
 }
@@ -441,10 +441,10 @@ export class YamlParser {
   /**
    * Extract variables from YAML content
    */
-  extractVariables(content: any): Record<string, any> {
-    const variables: Record<string, any> = {};
+  extractVariables(content: unknown): Record<string, unknown> {
+    const variables: Record<string, unknown> = {};
 
-    const extract = (obj: any, path: string = '') => {
+    const extract = (obj: unknown, path: string = '') => {
       if (typeof obj !== 'object' || obj === null) return;
 
       if (Array.isArray(obj)) {


### PR DESCRIPTION
## Summary

Closes #55

Pragmatically reduces explicit `any` type usages from **175 → 140** (35 fewer) in non-test TypeScript source files by replacing `any` with proper types where safe and simple:

- **logger.ts** — All log method `meta` params changed from `any` to `unknown` (handles `Error` objects, typed structs, and catch-block unknowns safely). `LogContext.metadata` and `performance()` metadata typed with `Record<string, unknown>`.
- **fileUtils.ts** — `readJsonFile<T = unknown>`, `writeJsonFile(data: unknown)`, and the `readJson`/`writeJson` convenience wrappers.
- **config.ts** — `fileConfig` typed as `unknown`, `envConfig` as `Record<string, unknown>`, `validateConfig` accepts `Partial<TestConfig>`, `parseEnvValue` returns `unknown`, `setNestedValue` value param is `unknown`, `getNestedValue` returns `unknown`.
- **yamlParser.ts** — `ValidationError.value` is `unknown`, `VariableContext.global/scenario` use `Record<string, unknown>`, `RawScenario` step/verification/cleanup arrays use `unknown[]`, `variableResolvers` use `(value: unknown) => unknown`, `extractVariables` returns `Record<string, unknown>`.
- **utils/index.ts** — `LegacyConfigManager` internal config map and set/get methods use `unknown`.
- **models/TestModels.ts** — `TestAssertion.value/expected` are `unknown`, `TestSession.config` is `unknown`.
- **models/TUIModels.ts** — `TUIScreenAssertion.expected`, verification `expected/actual` are `unknown`.
- **agents/system/types.ts** — `SystemIssue.details` and `PerformanceIssue.details` are `unknown`.
- **core/AdaptiveWaiter.ts** — `waitForAny` return type is `WaitResult<unknown>`.

## What was NOT changed (per spec)
- `any` in `__tests__/` and `.test.ts` files — test mocks legitimately use `any`
- `any` in PTY/third-party type workarounds (e.g., PTYManager options cast)
- Internal `mergeConfigs` generic constraint — `TestConfig` lacks an index signature so `Record<string, any>` is required
- Agent files with complex dynamics (CLIAgent, ElectronUIAgent, WebSocketAgent, APIAgent) — would require significant refactoring
- `noImplicitAny: true` — already present in tsconfig.json

## Test plan
- [x] `npx tsc --noEmit` — passes clean
- [x] `src/__tests__/config.test.ts` — 65 tests pass
- [x] `src/__tests__/yamlParser.test.ts` — 40 tests pass
- [x] `src/__tests__/AdaptiveWaiter.test.ts` — all tests pass
- [x] `src/__tests__/scenarioLoader.test.ts` — 14 tests pass
- [x] `src/__tests__/retry.test.ts` — tests pass
- [x] `src/__tests__/scenarioAdapter.test.ts` — tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)