### PR TITLE
fix: resolve quality issues #79, #80, #81

### DIFF
--- a/src/core/AdaptiveWaiter.ts
+++ b/src/core/AdaptiveWaiter.ts
@@ -218,12 +218,8 @@ export class AdaptiveWaiter {
     options: WaitOptions = {}
   ): Promise<WaitResult<T>> {
     return this.waitForCondition(async () => {
-      try {
-        const result = await operation();
-        return result as T;
-      } catch (error) {
-        throw error; // Let waitForCondition handle the retry logic
-      }
+      const result = await operation();
+      return result as T;
     }, options);
   }
 
@@ -296,8 +292,7 @@ export class AdaptiveWaiter {
     const actualDelay = Math.max(1, ms + jitterMs);
 
     return new Promise(resolve => {
-      const timer = setTimeout(() => resolve(), actualDelay);
-      return timer;
+      setTimeout(() => resolve(), actualDelay);
     });
   }
 

--- a/src/core/PtyTerminal.ts
+++ b/src/core/PtyTerminal.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events';
 import * as pty from 'node-pty-prebuilt-multiarch';
 import { ProcessLifecycleManager, ProcessInfo } from './ProcessLifecycleManager';
 import { adaptiveWaiter, waitForTerminalReady, waitForOutput, delay } from './AdaptiveWaiter';
+import { logger } from '../utils/logger';
 
 /**
  * Terminal dimensions
@@ -332,7 +333,7 @@ export class PtyTerminal extends EventEmitter {
         try {
           this.ptyProcess.kill();
         } catch (error) {
-          // Ignore errors during cleanup
+          logger.warn('Error killing PTY process during cleanup:', error);
         }
         this.ptyProcess = null;
       }

--- a/src/runners/ComprehensiveUITestRunner.ts
+++ b/src/runners/ComprehensiveUITestRunner.ts
@@ -69,16 +69,17 @@ export class ComprehensiveUITestRunner {
       const p = this.page;
       const t = this.tester;
 
-      await t.testTab(p, 'Build',         [t.testTenantIdInput.bind(t), t.testBuildButton.bind(t)]);
-      await t.testTab(p, 'Generate Spec', [t.testSpecGeneration.bind(t)]);
-      await t.testTab(p, 'Generate IaC',  [t.testFormatSelector.bind(t)]);
-      await t.testTab(p, 'Create Tenant', [t.testSpecUpload.bind(t)]);
-      await t.testTab(p, 'Visualize',     [t.testGraphVisualization.bind(t)]);
-      await t.testTab(p, 'Agent Mode',    [t.testAgentInterface.bind(t)]);
-      await t.testTab(p, 'Threat Model',  [t.testThreatModelGeneration.bind(t)]);
-      await t.testTab(p, 'Config',        [t.testConfigFields.bind(t), t.testSaveConfig.bind(t)]);
-      await t.testTab(p, 'Status',        [t.testSystemStatus.bind(t), t.testNeo4jStatus.bind(t)]);
-      await t.testTab(p, 'Help',          [t.testHelpContent.bind(t)]);
+      const addScreenshot = (p: string | null) => { if (p) screenshots.push(p); };
+      addScreenshot(await t.testTab(p, 'Build',         [t.testTenantIdInput.bind(t), t.testBuildButton.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Generate Spec', [t.testSpecGeneration.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Generate IaC',  [t.testFormatSelector.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Create Tenant', [t.testSpecUpload.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Visualize',     [t.testGraphVisualization.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Agent Mode',    [t.testAgentInterface.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Threat Model',  [t.testThreatModelGeneration.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Config',        [t.testConfigFields.bind(t), t.testSaveConfig.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Status',        [t.testSystemStatus.bind(t), t.testNeo4jStatus.bind(t)]));
+      addScreenshot(await t.testTab(p, 'Help',          [t.testHelpContent.bind(t)]));
 
       // Responsiveness tests
       t.logSection('UI Responsiveness Tests');

--- a/src/runners/comprehensive/UIFlowTester.ts
+++ b/src/runners/comprehensive/UIFlowTester.ts
@@ -83,8 +83,9 @@ export class UIFlowTester {
 
   /**
    * Navigate to a named tab, capture a screenshot, then run the provided tests.
+   * Returns the screenshot path if captured, or null on failure.
    */
-  async testTab(page: Page, tabName: string, tests: TabTestFunction[]): Promise<void> {
+  async testTab(page: Page, tabName: string, tests: TabTestFunction[]): Promise<string | null> {
     this.logSection(`Testing ${tabName} Tab`);
 
     try {
@@ -103,8 +104,11 @@ export class UIFlowTester {
           this.logError(test.name || 'Unknown test', error as Error);
         }
       }
+
+      return screenshotPath;
     } catch (error) {
       this.logError(`Failed to test ${tabName} tab`, error as Error);
+      return null;
     }
   }
 

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -6,21 +6,23 @@
  */
 
 // Smart UI Test Runner - Uses Playwright's accessibility tree and element detection
-export {
+import {
   SmartUITestRunner,
   createSmartUITestRunner,
   runSmartUITests
 } from './SmartUITestRunner';
+export { SmartUITestRunner, createSmartUITestRunner, runSmartUITests };
 
 // Comprehensive UI Test Runner - Systematically exercises all tabs and features
-export {
+import {
   ComprehensiveUITestRunner,
   createComprehensiveUITestRunner,
   runComprehensiveUITests
 } from './ComprehensiveUITestRunner';
+export { ComprehensiveUITestRunner, createComprehensiveUITestRunner, runComprehensiveUITests };
 
 // Re-export common types for convenience
-export type { TestResult, TestStatus, TestStep } from '../models/TestModels';
+export type { TestResult, TestStatus } from '../models/TestModels';
 
 /**
  * Available test runners
@@ -49,16 +51,11 @@ export function createTestRunner(
   type: TestRunnerType,
   config?: RunnerConfig
 ) {
-  // Dynamic imports to avoid circular dependencies
   switch (type) {
-    case TestRunners.Smart: {
-      const { createSmartUITestRunner } = require('./SmartUITestRunner');
+    case TestRunners.Smart:
       return createSmartUITestRunner(config?.screenshotsDir);
-    }
-    case TestRunners.Comprehensive: {
-      const { createComprehensiveUITestRunner } = require('./ComprehensiveUITestRunner');
+    case TestRunners.Comprehensive:
       return createComprehensiveUITestRunner(config?.screenshotsDir);
-    }
     default:
       throw new Error(`Unknown test runner type: ${type}`);
   }
@@ -71,16 +68,11 @@ export async function runTestRunner(
   type: TestRunnerType,
   config?: RunnerConfig
 ) {
-  // Dynamic imports to avoid circular dependencies
   switch (type) {
-    case TestRunners.Smart: {
-      const { runSmartUITests } = require('./SmartUITestRunner');
+    case TestRunners.Smart:
       return await runSmartUITests(config?.screenshotsDir);
-    }
-    case TestRunners.Comprehensive: {
-      const { runComprehensiveUITests } = require('./ComprehensiveUITestRunner');
+    case TestRunners.Comprehensive:
       return await runComprehensiveUITests(config?.screenshotsDir);
-    }
     default:
       throw new Error(`Unknown test runner type: ${type}`);
   }

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared ANSI colour codes for terminal output.
+ * Import this instead of duplicating the object in each file.
+ */
+export const colors = {
+  green:   '\x1b[32m',
+  red:     '\x1b[31m',
+  yellow:  '\x1b[33m',
+  blue:    '\x1b[34m',
+  cyan:    '\x1b[36m',
+  magenta: '\x1b[35m',
+  reset:   '\x1b[0m'
+} as const;
+
+export type ColorKey = keyof typeof colors;


### PR DESCRIPTION
## Summary

- **#79** `ComprehensiveUITestRunner` screenshots always empty: changed `testTab()` return type to `Promise<string | null>`, returns the screenshot path, and `runTests()` accumulates all paths so `TestResult.screenshots` is populated.
- **#80** `SmartUITestRunner` variable shadowing: renamed inner `tabElements` (discovered inside loop body) to `currentTabElements` to eliminate the shadowing of the outer `tabElements` loop variable.
- **#81** Multiple small quality fixes:
  - `runners/index.ts`: removed redundant dynamic `require()` calls; uses already-statically-imported functions directly.
  - `PtyTerminal.ts`: replaced silent `// Ignore errors during cleanup` catch with `logger.warn()`.
  - `TestOrchestrator.ts`: removed redundant dynamic `import()` of `adaptScenarioToComplex` inside `runWithScenarios()` (static top-level import used instead); converted three inline `import()` type expressions in method signatures to proper top-level `import type` declarations.
  - `AdaptiveWaiter.ts`: removed no-op `try { ... } catch (error) { throw error; }` wrapper in `retryOperation()`; removed no-effect `return timer` inside Promise executor in `delay()`.
  - `orchestrator/index.ts`: changed `TestSuite` and `OrchestratorEvents` re-exports to `export type` (they are interfaces).
  - Removed unused `TestStep` imports from both runner files.
  - Extracted duplicate `colors` ANSI constant to `src/utils/colors.ts` and imported in both runners.

## Test plan

- [x] `npx tsc --noEmit` passes cleanly (zero errors)
- [x] `npx jest --no-coverage --forceExit` — 326 tests pass; 15 pre-existing failures in `ZombieProcessPrevention`, `tests/TUIAgent`, `tests/terminal.integration`, and `SystemAgent.basic` are unchanged from the main branch (confirmed by running the same failing suites against `main`)
- [x] `AdaptiveWaiter.test.ts` passes — confirms `retryOperation` and `delay` fixes are correct
- [x] Reviewed diff for all 8 changed/created files

Closes #79
Closes #80
Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)