### PR TITLE
security: prevent credential exposure via process.env snapshot (fixes #84)

### DIFF
--- a/src/__tests__/lib.security.test.ts
+++ b/src/__tests__/lib.security.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Security regression tests for issue #84:
+ * process.env snapshot with credentials stored in TestConfig (written to disk)
+ *
+ * These tests verify that createDefaultConfig() does NOT copy secrets from
+ * process.env into the TestConfig. Credentials like GITHUB_TOKEN, AWS_* and
+ * AZURE_* must never appear in cli.environment or tui.environment because
+ * TestConfig objects are serialised to disk by saveResults and exportToFile.
+ */
+
+// Mock heavy dependencies that the orchestrator pulls in so the test module
+// loads quickly without spawning child processes or opening file handles.
+jest.mock('../orchestrator', () => ({
+  createTestOrchestrator: jest.fn(),
+  TestOrchestrator: jest.fn()
+}));
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  setupLogger: jest.fn(),
+  LogLevel: { INFO: 'INFO', DEBUG: 'DEBUG', WARN: 'WARN', ERROR: 'ERROR' }
+}));
+jest.mock('../utils/config', () => {
+  const actual = jest.requireActual('../utils/config');
+  return actual;
+});
+jest.mock('../utils/yamlParser', () => ({
+  parseYamlScenarios: jest.fn().mockResolvedValue([])
+}));
+jest.mock('fs-extra', () => ({
+  pathExists: jest.fn().mockResolvedValue(false)
+}));
+
+import { createDefaultConfig } from '../lib';
+
+describe('Security: createDefaultConfig credential exposure prevention (issue #84)', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('GITHUB_TOKEN is not in cli.environment', () => {
+    process.env.GITHUB_TOKEN = 'ghp_supersecrettoken';
+
+    const config = createDefaultConfig();
+
+    expect(config.cli.environment['GITHUB_TOKEN']).toBeUndefined();
+  });
+
+  it('GITHUB_TOKEN is not in tui.environment', () => {
+    process.env.GITHUB_TOKEN = 'ghp_supersecrettoken';
+
+    const config = createDefaultConfig();
+
+    expect(config.tui.environment['GITHUB_TOKEN']).toBeUndefined();
+  });
+
+  it('AWS_SECRET_ACCESS_KEY is not in cli.environment', () => {
+    process.env.AWS_SECRET_ACCESS_KEY = 'aws-super-secret';
+
+    const config = createDefaultConfig();
+
+    expect(config.cli.environment['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
+  });
+
+  it('AWS_ACCESS_KEY_ID is not in cli.environment', () => {
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+
+    const config = createDefaultConfig();
+
+    expect(config.cli.environment['AWS_ACCESS_KEY_ID']).toBeUndefined();
+  });
+
+  it('AZURE_CLIENT_SECRET is not in cli.environment', () => {
+    process.env.AZURE_CLIENT_SECRET = 'azure-secret';
+
+    const config = createDefaultConfig();
+
+    expect(config.cli.environment['AZURE_CLIENT_SECRET']).toBeUndefined();
+  });
+
+  it('tui.environment is an empty object by default regardless of process.env', () => {
+    process.env.GITHUB_TOKEN = 'ghp_supersecrettoken';
+    process.env.MY_SECRET_KEY = 'topsecret';
+    process.env.AWS_SECRET_ACCESS_KEY = 'aws-super-secret';
+
+    const config = createDefaultConfig();
+
+    expect(Object.keys(config.tui.environment)).toHaveLength(0);
+  });
+
+  it('cli.environment only contains NODE_ENV - no mass env snapshot', () => {
+    process.env.GITHUB_TOKEN = 'ghp_supersecrettoken';
+    process.env.AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+    process.env.NODE_ENV = 'test';
+
+    const config = createDefaultConfig();
+    const cliEnvKeys = Object.keys(config.cli.environment);
+
+    expect(cliEnvKeys).toContain('NODE_ENV');
+    expect(cliEnvKeys).not.toContain('GITHUB_TOKEN');
+    expect(cliEnvKeys).not.toContain('AWS_ACCESS_KEY_ID');
+  });
+
+  it('cli.environment NODE_ENV defaults to "test" when not set', () => {
+    delete process.env.NODE_ENV;
+
+    const config = createDefaultConfig();
+
+    expect(config.cli.environment['NODE_ENV']).toBe('test');
+  });
+
+  it('cli.environment NODE_ENV respects the value from process.env', () => {
+    process.env.NODE_ENV = 'production';
+
+    const config = createDefaultConfig();
+
+    expect(config.cli.environment['NODE_ENV']).toBe('production');
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,12 +38,18 @@ export interface ValidationResult {
 
 /**
  * Configuration metadata
+ *
+ * NOTE: The `environment` field is intentionally kept empty.
+ * Snapshotting process.env would expose secrets (API keys, tokens,
+ * passwords) through any serialisation path. Use loadFromEnvironment()
+ * to read specific, named env vars into the TestConfig instead.
  */
 export interface ConfigMetadata {
   source: ConfigSource;
   loadedAt: Date;
   filePath?: string;
-  environment: Record<string, string>;
+  /** Always an empty object - never populated with process.env to prevent credential exposure. */
+  environment: Record<string, never>;
 }
 
 /**
@@ -201,7 +207,7 @@ export class ConfigManager {
     this.metadata = {
       source: ConfigSource.DEFAULT,
       loadedAt: new Date(),
-      environment: { ...process.env } as Record<string, string>
+      environment: {} // Don't snapshot env vars - they may contain secrets
     };
   }
 
@@ -236,7 +242,7 @@ export class ConfigManager {
         source: ConfigSource.FILE,
         loadedAt: new Date(),
         filePath: absolutePath,
-        environment: { ...process.env } as Record<string, string>
+        environment: {} // Don't snapshot env vars - they may contain secrets
       };
 
       // Notify watchers


### PR DESCRIPTION
## Summary

Fixes **CRITICAL** security vulnerability #84 where two code paths snapshot the entire `process.env` into `TestConfig`/`ConfigMetadata` objects that are serialised to disk:

- **Fix 1 - `src/utils/config.ts`**: `ConfigManager` constructor and `loadFromFile` both set `metadata.environment = { ...process.env }`. This exposed `GITHUB_TOKEN`, `AWS_*`, `AZURE_*` and all other secrets through any log or export. Changed to `{}` in both places. Updated `ConfigMetadata.environment` type from `Record<string, string>` to `Record<string, never>` so the compiler enforces it stays empty.
- **Fix 2 - `src/lib.ts`**: `createDefaultConfig()` built an `envVars` object from all of `process.env`, then spread it into `cli.environment` and assigned it to `tui.environment`. `TestConfig` is written to disk by `saveResults` and `ConfigManager.exportToFile`. Changed `cli.environment` to only include `NODE_ENV` (the one safe, non-secret var needed to run child processes) and `tui.environment` to `{}`.

## Security impact

Before this fix, any call to `saveResults()` or `ConfigManager.exportToFile()` would write a JSON/YAML file containing every environment variable on the host - including `GITHUB_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `AZURE_CLIENT_SECRET`, database passwords, API keys, etc.

## Test plan

- [x] `src/__tests__/config.test.ts` - 5 new security tests added; all 41 tests pass
- [x] `src/__tests__/lib.security.test.ts` - 9 new security regression tests for `createDefaultConfig`; all pass
- [x] `npx tsc --noEmit` passes with zero errors
- [x] Pre-existing test failures (`tests/TUIAgent.test.ts`, `tests/terminal.integration.test.ts`) are pre-existing and unrelated to this fix

## Files changed

- `src/utils/config.ts` - Remove `process.env` snapshot from `ConfigMetadata`; update interface type to `Record<string, never>`
- `src/lib.ts` - Replace full `process.env` copy with only `NODE_ENV` in `cli.environment`; empty `tui.environment`
- `src/__tests__/config.test.ts` - 5 new security tests for `ConfigManager`
- `src/__tests__/lib.security.test.ts` - New file: 9 regression tests for `createDefaultConfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)