### PR TITLE
fix: remove global uncaughtException/unhandledRejection from library module (#77)

### DIFF
--- a/src/core/ResourceOptimizer.ts
+++ b/src/core/ResourceOptimizer.ts
@@ -189,6 +189,28 @@ export class ResourceOptimizer extends EventEmitter {
 }
 
 /**
- * Singleton instance for global resource management
+ * Singleton instance for global resource management.
+ * Lazily initialised via a Proxy so that importing this module does not
+ * immediately start background monitoring timers.
  */
-export const resourceOptimizer = new ResourceOptimizer();
+let _globalResourceOptimizer: ResourceOptimizer | null = null;
+
+export function getResourceOptimizer(): ResourceOptimizer {
+  if (!_globalResourceOptimizer) {
+    _globalResourceOptimizer = new ResourceOptimizer();
+  }
+  return _globalResourceOptimizer;
+}
+
+export const resourceOptimizer: ResourceOptimizer = new Proxy(
+  {} as ResourceOptimizer,
+  {
+    get(_target, prop) {
+      return (getResourceOptimizer() as any)[prop];
+    },
+    set(_target, prop, value) {
+      (getResourceOptimizer() as any)[prop] = value;
+      return true;
+    }
+  }
+);

--- a/src/core/optimizer/CpuOptimizer.ts
+++ b/src/core/optimizer/CpuOptimizer.ts
@@ -28,7 +28,7 @@ export class CpuOptimizer extends EventEmitter {
     if (!this.config.rotationInterval) return;
     this.rotationInterval = setInterval(() => {
       this.rotateBuffers(false);
-    }, this.config.rotationInterval);
+    }, this.config.rotationInterval).unref();
   }
 
   /**

--- a/src/core/optimizer/MemoryOptimizer.ts
+++ b/src/core/optimizer/MemoryOptimizer.ts
@@ -54,7 +54,7 @@ export class MemoryOptimizer extends EventEmitter {
         this.emit('memoryAlert', usage);
         this.onRssExceeded?.();
       }
-    }, this.config.monitorInterval);
+    }, this.config.monitorInterval).unref();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #77 — `ProcessLifecycleManager` was registering `uncaughtException` and `unhandledRejection` handlers (which call `process.exit(1)`) at module import time via its eagerly-evaluated singleton. This caused Jest to exit on the first unhandled rejection and broke any library consumer.

- **ProcessLifecycleManager**: Remove `uncaughtException`, `unhandledRejection`, `SIGTERM`, and `SIGINT` handlers entirely from the class. Only a safe synchronous `process.on('exit')` handler remains (no `process.exit()` call, safe for library use). Removed `registerSignalHandlers()` method and associated static fields (`globalHandlersRegistered`, `globalSignalHandler`, `globalExitHandlersRegistered`). Replaced with single `registerExitHandler()` guarded by `globalExitHandlerRegistered`.
- **processLifecycleManager singleton**: Changed from eagerly-executed IIFE to a lazy `Proxy`. Added `getProcessLifecycleManager()` named export for explicit access. Backward-compatible: existing `processLifecycleManager.startProcess(...)` usage still works.
- **ResourceOptimizer**: Added `.unref()` to both `setInterval` calls (`memoryMonitorInterval`, `bufferRotationInterval`) so they do not keep the Node.js event loop alive. Made `resourceOptimizer` singleton lazy via `Proxy` + `getResourceOptimizer()` named export.
- **cli.ts**: Added global `SIGTERM` and `SIGINT` handlers that call `ProcessLifecycleManager.shutdown()` before exiting. Updated existing `uncaughtException` / `unhandledRejection` handlers to also invoke shutdown. These handlers belong only in the CLI entry point, not in library modules.

## Test plan

- [x] `ProcessLifecycleManager.test.ts` — all 18 tests pass
- [x] `ResourceOptimizer.test.ts` — all 22 tests pass
- [x] Full test suite run confirms no new failures introduced (pre-existing failures in `SystemAgent.test.ts`, `ZombieProcessPrevention.test.ts`, `terminal.integration.test.ts`, `tests/TUIAgent.test.ts` are unchanged from main)
- [x] TypeScript compiles without errors (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)