### PR TITLE
fix(security): prevent CLI path traversal via --directory/--file/--config flags (#93)

### DIFF
--- a/src/__tests__/safeResolvePath.test.ts
+++ b/src/__tests__/safeResolvePath.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for safeResolvePath - path traversal prevention (issue #93)
+ *
+ * Ensures user-supplied path arguments cannot escape the allowed base directory
+ * via traversal sequences like ../../etc/passwd.
+ */
+
+import * as path from 'path';
+
+// We import the function under test from its module location.
+// safeResolvePath is exported from cli-path-utils for testability.
+import { safeResolvePath } from '../cli-path-utils';
+
+describe('safeResolvePath', () => {
+  const base = '/tmp/test-base';
+
+  describe('legitimate relative paths', () => {
+    it('allows a simple relative subdirectory', () => {
+      const result = safeResolvePath('./scenarios', base);
+      expect(result).toBe(path.join(base, 'scenarios'));
+    });
+
+    it('allows a nested relative path', () => {
+      const result = safeResolvePath('foo/bar/baz', base);
+      expect(result).toBe(path.join(base, 'foo', 'bar', 'baz'));
+    });
+
+    it('allows the base directory itself (dot)', () => {
+      const result = safeResolvePath('.', base);
+      expect(result).toBe(base);
+    });
+
+    it('allows a relative path with no leading dot', () => {
+      const result = safeResolvePath('scenarios/my-test.yaml', base);
+      expect(result).toBe(path.join(base, 'scenarios', 'my-test.yaml'));
+    });
+  });
+
+  describe('path traversal attacks', () => {
+    it('rejects a simple double-dot traversal', () => {
+      expect(() => safeResolvePath('../etc/passwd', base)).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+
+    it('rejects a deep traversal attempt', () => {
+      expect(() => safeResolvePath('../../../etc/passwd', base)).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+
+    it('rejects a traversal that goes up and then down into a sibling', () => {
+      expect(() => safeResolvePath('../sibling-dir/file.txt', base)).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+
+    it('rejects a traversal sequence embedded in a longer path', () => {
+      expect(() => safeResolvePath('scenarios/../../etc/shadow', base)).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+
+    it('rejects a path that resolves exactly to the parent directory', () => {
+      // Resolves to /tmp/test-base/.. which is /tmp
+      expect(() => safeResolvePath('..', base)).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+  });
+
+  describe('absolute paths', () => {
+    it('allows an absolute path that is inside the base directory', () => {
+      const insidePath = path.join(base, 'subdir', 'file.yaml');
+      const result = safeResolvePath(insidePath, base);
+      expect(result).toBe(insidePath);
+    });
+
+    it('rejects an absolute path outside the base directory', () => {
+      expect(() => safeResolvePath('/etc/passwd', base)).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+
+    it('rejects an absolute path to /tmp (parent of base)', () => {
+      expect(() => safeResolvePath('/tmp', base)).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('allows a path equal to the base directory itself', () => {
+      const result = safeResolvePath(base, base);
+      expect(result).toBe(base);
+    });
+
+    it('uses process.cwd() as the default base when none is supplied', () => {
+      const cwd = process.cwd();
+      const result = safeResolvePath('./relative-path');
+      expect(result).toBe(path.join(cwd, 'relative-path'));
+    });
+
+    it('rejects traversal even when base is process.cwd()', () => {
+      expect(() => safeResolvePath('../../etc/passwd')).toThrow(
+        /escapes the allowed directory/
+      );
+    });
+
+    it('handles a path with encoded-looking sequences (plain string, not URL)', () => {
+      // Node path.resolve does NOT decode URL encoding - literal %2F is kept
+      // A path like 'foo%2F..%2Fetc' is treated as a filename component, not traversal
+      const result = safeResolvePath('foo%2F..%2Fetc', base);
+      expect(result).toBe(path.join(base, 'foo%2F..%2Fetc'));
+    });
+  });
+});

--- a/src/cli-path-utils.ts
+++ b/src/cli-path-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * CLI path utilities — safe path resolution to prevent directory traversal.
+ *
+ * Issue #93: User-supplied --directory, --file, --config, and --scenario values
+ * must be bounds-checked before being passed to file I/O.  An attacker could
+ * otherwise supply `../../etc/passwd` to read arbitrary files on the host.
+ *
+ * Rules enforced by safeResolvePath:
+ *   1. Relative paths are resolved against `base` (defaults to process.cwd()).
+ *   2. The resolved path must start with `base + path.sep` OR equal `base`
+ *      exactly.  Anything outside that range throws CLIPathError.
+ *   3. Absolute paths supplied by the user are validated against the same
+ *      bounds — they must still reside inside `base`.
+ */
+
+import * as path from 'path';
+
+/** Thrown when a user-supplied path attempts to escape the allowed directory. */
+export class CLIPathError extends Error {
+  constructor(input: string, base: string) {
+    super(
+      `Path '${input}' escapes the allowed directory '${base}'. ` +
+        `Use an absolute path that is inside the allowed directory, ` +
+        `or a relative path that does not traverse above it.`
+    );
+    this.name = 'CLIPathError';
+  }
+}
+
+/**
+ * Resolve `input` relative to `base` and verify the result stays inside `base`.
+ *
+ * @param input - The raw path string provided by the user (e.g., from a CLI flag).
+ * @param base  - The directory that `input` must reside within.
+ *                Defaults to `process.cwd()`.
+ * @returns The absolute, canonical path string.
+ * @throws CLIPathError if the resolved path escapes `base`.
+ */
+export function safeResolvePath(
+  input: string,
+  base: string = process.cwd()
+): string {
+  const resolvedBase = path.resolve(base);
+  const resolved = path.resolve(resolvedBase, input);
+
+  // Allow the path if it is exactly the base dir or a descendant of it.
+  const isExactBase = resolved === resolvedBase;
+  const isDescendant = resolved.startsWith(resolvedBase + path.sep);
+
+  if (!isExactBase && !isDescendant) {
+    throw new CLIPathError(input, resolvedBase);
+  }
+
+  return resolved;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import chalk from 'chalk';
 import * as dotenv from 'dotenv';
 import { SingleBar, Presets } from 'cli-progress';
 import { createDefaultConfig } from './lib';
+import { safeResolvePath, CLIPathError } from './cli-path-utils';
 
 // Load environment variables from .env file if it exists
 try {
@@ -77,9 +78,22 @@ program
   .action(async (options) => {
     try {
       logger.info('Starting Agentic Testing System');
-      
+
       let config = null;
-      
+
+      // Validate and resolve user-supplied paths (prevent path traversal - issue #93)
+      try {
+        options.directory = safeResolvePath(options.directory);
+        if (options.config) {
+          options.config = safeResolvePath(options.config);
+        }
+      } catch (err) {
+        if (err instanceof CLIPathError) {
+          throw new CLIError(err.message, 'PATH_TRAVERSAL');
+        }
+        throw err;
+      }
+
       // Load configuration if provided
       if (options.config) {
         try {
@@ -88,19 +102,20 @@ program
           config = configManager.getConfig();
           logSuccess(`Configuration loaded from: ${options.config}`);
         } catch (error: any) {
+          if (error instanceof CLIError) throw error;
           throw new CLIError(`Failed to load configuration: ${error.message}`, 'CONFIG_ERROR');
         }
       } else {
         // Try loading default config files
         const defaultConfigs = [
           'agentic-test.config.yaml',
-          'agentic-test.config.yml', 
+          'agentic-test.config.yml',
           'agentic-test.config.json',
           '.agentic-testrc.yaml',
           '.agentic-testrc.yml',
           '.agentic-testrc.json'
         ];
-        
+
         for (const configFile of defaultConfigs) {
           try {
             await fs.access(configFile);
@@ -114,22 +129,25 @@ program
           }
         }
       }
-      
+
       // Validate scenario directory exists
       try {
         await fs.access(options.directory);
       } catch {
         throw new CLIError(`Scenarios directory not found: ${options.directory}`, 'DIRECTORY_NOT_FOUND');
       }
-      
+
       let scenarios;
       const progressBar = createProgressBar(1, 'Loading scenarios');
       progressBar.start(1, 0);
-      
+
       try {
         if (options.scenario) {
-          // Load specific scenario
-          const scenarioPath = path.join(options.directory, `${options.scenario}.yaml`);
+          // Build scenario path and validate it stays within the resolved directory.
+          // options.scenario is a name (e.g. "my-test"), not a path, but we still
+          // guard against names containing traversal sequences like "../../etc/passwd".
+          const rawScenarioPath = path.join(options.directory, `${options.scenario}.yaml`);
+          const scenarioPath = safeResolvePath(rawScenarioPath, options.directory);
           logInfo(`Loading scenario: ${scenarioPath}`);
           scenarios = [await ScenarioLoader.loadFromFile(scenarioPath)];
         } else {
@@ -212,18 +230,31 @@ program
   .option('-c, --config <file>', 'Configuration file')
   .action(async (options) => {
     try {
+      // Validate and resolve user-supplied paths (prevent path traversal - issue #93)
+      try {
+        options.directory = safeResolvePath(options.directory);
+        if (options.config) {
+          options.config = safeResolvePath(options.config);
+        }
+      } catch (err) {
+        if (err instanceof CLIPathError) {
+          throw new CLIError(err.message, 'PATH_TRAVERSAL');
+        }
+        throw err;
+      }
+
       logInfo('Starting watch mode...');
       logInfo(`Watching directory: ${chalk.cyan(options.directory)}`);
-      
+
       // Validate directory exists
       try {
         await fs.access(options.directory);
       } catch {
         throw new CLIError(`Watch directory not found: ${options.directory}`, 'DIRECTORY_NOT_FOUND');
       }
-      
+
       let config = null;
-      
+
       // Load configuration if provided
       if (options.config) {
         try {
@@ -232,6 +263,7 @@ program
           config = configManager.getConfig();
           logSuccess(`Configuration loaded from: ${options.config}`);
         } catch (error: any) {
+          if (error instanceof CLIError) throw error;
           throw new CLIError(`Failed to load configuration: ${error.message}`, 'CONFIG_ERROR');
         }
       }
@@ -352,14 +384,28 @@ program
   .option('--strict', 'Enable strict validation mode')
   .action(async (options) => {
     try {
+      // Validate and resolve user-supplied paths (prevent path traversal - issue #93)
+      try {
+        if (options.file) {
+          options.file = safeResolvePath(options.file);
+        } else {
+          options.directory = safeResolvePath(options.directory);
+        }
+      } catch (err) {
+        if (err instanceof CLIPathError) {
+          throw new CLIError(err.message, 'PATH_TRAVERSAL');
+        }
+        throw err;
+      }
+
       logInfo('Validating scenarios...');
-      
+
       const parser = createYamlParser({
         strictValidation: options.strict || false
       });
-      
+
       let validationResults: Array<{file: string; valid: boolean; errors: string[]}> = [];
-      
+
       if (options.file) {
         try {
           await fs.access(options.file);
@@ -369,12 +415,13 @@ program
             valid: result.valid,
             errors: result.errors
           });
-          
+
           if (result.valid) {
             const scenario = await ScenarioLoader.loadFromFile(options.file);
             logSuccess(`Scenario "${scenario.name}" is valid`);
           }
         } catch (error: any) {
+          if (error instanceof CLIError) throw error;
           validationResults.push({
             file: options.file,
             valid: false,
@@ -471,13 +518,23 @@ program
   .option('--filter <tag>', 'Filter by tag')
   .action(async (options) => {
     try {
+      // Validate and resolve user-supplied paths (prevent path traversal - issue #93)
+      try {
+        options.directory = safeResolvePath(options.directory);
+      } catch (err) {
+        if (err instanceof CLIPathError) {
+          throw new CLIError(err.message, 'PATH_TRAVERSAL');
+        }
+        throw err;
+      }
+
       // Validate directory exists
       try {
         await fs.access(options.directory);
       } catch {
         throw new CLIError(`Directory not found: ${options.directory}`, 'DIRECTORY_NOT_FOUND');
       }
-      
+
       const scenarios = await ScenarioLoader.loadFromDirectory(options.directory);
       
       if (scenarios.length === 0) {
@@ -560,8 +617,18 @@ program
   .option('--template <type>', 'Project template (basic, advanced, electron)', 'basic')
   .action(async (options) => {
     try {
+      // Validate and resolve user-supplied paths (prevent path traversal - issue #93)
+      try {
+        options.directory = safeResolvePath(options.directory);
+      } catch (err) {
+        if (err instanceof CLIPathError) {
+          throw new CLIError(err.message, 'PATH_TRAVERSAL');
+        }
+        throw err;
+      }
+
       logInfo(`Initializing new testing project in: ${chalk.cyan(options.directory)}`);
-      
+
       // Check if directory exists
       let directoryExists = false;
       try {
@@ -676,10 +743,16 @@ program
     // Load additional .env file if specified
     if (opts.env && opts.env !== '.env') {
       try {
-        dotenv.config({ path: opts.env });
-        logInfo(`Loaded environment from: ${opts.env}`);
+        // Validate the env file path to prevent traversal (issue #93)
+        const safeEnvPath = safeResolvePath(opts.env);
+        dotenv.config({ path: safeEnvPath });
+        logInfo(`Loaded environment from: ${safeEnvPath}`);
       } catch (error) {
-        logWarning(`Failed to load environment file: ${opts.env}`);
+        if (error instanceof CLIPathError) {
+          logWarning(`Rejected environment file path (path traversal attempt): ${opts.env}`);
+        } else {
+          logWarning(`Failed to load environment file: ${opts.env}`);
+        }
       }
     }
     


### PR DESCRIPTION
## Summary

- Closes #93 (CRITICAL security — path traversal in CLI path flags)
- Adds `safeResolvePath` in `src/cli-path-utils.ts`: resolves a user-supplied path against `process.cwd()` and rejects it if the result escapes the base directory
- Applied to all five CLI commands (`run`, `watch`, `validate`, `list`, `init`) and the global `--env` flag — covering `--directory`, `--file`, `--config`, `--scenario`, and `--env` arguments
- Adds `CLIPathError` (extends `Error`) so path-traversal rejections surface as a distinct, testable error type with error code `PATH_TRAVERSAL`
- 16 new unit tests in `src/__tests__/safeResolvePath.test.ts`; TypeScript compiles cleanly with `--noEmit`

## Security properties enforced

| Property | Behaviour |
|---|---|
| Relative traversal (`../../etc/passwd`) | Rejected — throws `CLIPathError` |
| Deep traversal (`../../../sensitive`) | Rejected |
| Embedded traversal (`scenarios/../../etc`) | Rejected |
| Absolute path inside cwd | Allowed |
| Absolute path outside cwd (`/etc/passwd`) | Rejected |
| Legitimate relative path (`./scenarios`) | Allowed, resolved to absolute form |
| Base directory itself (`.`) | Allowed |

## Test plan

- [x] `npx tsc --noEmit` — compiles without errors
- [x] `npx jest --testPathPattern=safeResolvePath` — 16/16 tests pass
- [x] `npx jest --no-coverage --forceExit` — 229 tests pass (3 pre-existing integration-test failures unrelated to this change: `ZombieProcessPrevention`, `tests/TUIAgent.test.ts`, `tests/terminal.integration.test.ts`)
- [x] Verify `./scenarios` still works (relative paths within cwd are allowed)
- [x] Verify `../../etc/passwd` is rejected with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)