### PR TITLE
fix: multiple agent quality fixes (#99)

### DIFF
--- a/src/agents/APIAgent.ts
+++ b/src/agents/APIAgent.ts
@@ -533,12 +533,6 @@ export class APIAgent extends EventEmitter implements IAgent {
           result = true;
           break;
           
-        case 'clear_cookies':
-          // Note: Axios doesn't handle cookies automatically like browsers
-          // This would need to be implemented if cookie support is needed
-          result = true;
-          break;
-          
         default:
           throw new Error(`Unsupported API action: ${step.action}`);
       }
@@ -896,7 +890,7 @@ export class APIAgent extends EventEmitter implements IAgent {
   }
 
   private generateRequestId(): string {
-    return `${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
   }
 
   private applyEnvironmentConfig(environment: Record<string, string>): void {
@@ -919,7 +913,15 @@ export class APIAgent extends EventEmitter implements IAgent {
   }
 
   private getScenarioLogs(): string[] {
-    return this.logger ? ['No scenario-specific logs available'] : [];
+    const logs: string[] = [];
+    for (const response of this.responseHistory) {
+      const req = this.requestHistory.find(r => r.id === response.requestId);
+      const method = req ? req.method : 'UNKNOWN';
+      const url = req ? req.url : 'unknown';
+      const ts = response.timestamp.toISOString();
+      logs.push(`[${ts}] ${method} ${url} → ${response.status} ${response.statusText} (${response.duration}ms)`);
+    }
+    return logs;
   }
 
   private setupEventListeners(): void {

--- a/src/agents/CLIAgent.ts
+++ b/src/agents/CLIAgent.ts
@@ -559,7 +559,7 @@ export class CLIAgent extends EventEmitter implements IAgent {
 
   private async executeWithRetry(context: ExecutionContext, attempt: number): Promise<CommandResult> {
     const fullCommand = `${context.command} ${context.args.join(' ')}`.trim();
-    const processId = `${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const processId = `${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
     
     return new Promise((resolve, reject) => {
       const startTime = Date.now();

--- a/src/agents/ElectronUIAgent.ts
+++ b/src/agents/ElectronUIAgent.ts
@@ -698,7 +698,7 @@ export class ElectronUIAgent extends EventEmitter implements IAgent {
 
       // Store state snapshot
       const snapshot: StateSnapshot = {
-        id: `${timestamp.getTime()}_${Math.random().toString(36).substr(2, 9)}`,
+        id: `${timestamp.getTime()}_${Math.random().toString(36).slice(2, 11)}`,
         timestamp,
         state,
         scenarioId: this.currentScenarioId

--- a/src/agents/IssueReporter.ts
+++ b/src/agents/IssueReporter.ts
@@ -635,7 +635,7 @@ export class IssueReporter {
     let stackTraceHash: string | undefined;
     if (failure.stackTrace) {
       stackTraceHash = crypto
-        .createHash('md5')
+        .createHash('sha256')
         .update(failure.stackTrace)
         .digest('hex')
         .substring(0, 8);
@@ -866,13 +866,17 @@ export class IssueReporter {
     if (this.rateLimitInfo && this.rateLimitInfo.remaining <= this.config.rateLimitBuffer!) {
       const waitTime = this.rateLimitInfo.reset.getTime() - Date.now();
       if (waitTime > 0) {
+        const MAX_WAIT_MS = 60_000;
+        if (waitTime > MAX_WAIT_MS) {
+          throw new Error(`GitHub rate limit exceeded, would need to wait ${Math.ceil(waitTime / 1000)}s. Try again later.`);
+        }
         this.logger.warn('Rate limit approaching, waiting for reset', {
           remaining: this.rateLimitInfo.remaining,
           resetTime: this.rateLimitInfo.reset.toISOString(),
           waitTimeMs: waitTime
         });
-        
-        await new Promise(resolve => setTimeout(resolve, waitTime + 1000));
+
+        await new Promise(resolve => setTimeout(resolve, Math.min(waitTime + 1000, MAX_WAIT_MS)));
         await this.updateRateLimitInfo();
       }
     }

--- a/src/agents/TUIAgent.ts
+++ b/src/agents/TUIAgent.ts
@@ -882,7 +882,7 @@ export class TUIAgent extends EventEmitter implements IAgent {
   }
 
   private generateSessionId(): string {
-    return `tui_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `tui_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
   }
 
   private processSpecialKeys(input: string): string {
@@ -1276,16 +1276,8 @@ export class TUIAgent extends EventEmitter implements IAgent {
     await this.waitForOutputPattern(sessionId, pattern, timeout);
   }
 
-  private async handleResizeTerminalAction(step: TestStep): Promise<void> {
-    const sessionId = step.target || this.getMostRecentSessionId();
-    const [cols, rows] = (step.value || '80,24').split(',').map(Number);
-
-    const session = this.sessions.get(sessionId);
-    if (session) {
-      session.size = { cols, rows };
-      // In a real implementation, you would resize the actual terminal
-      this.logger.debug(`Terminal resized`, { sessionId, cols, rows });
-    }
+  private async handleResizeTerminalAction(_step: TestStep): Promise<void> {
+    throw new Error('resize_terminal action is not yet implemented');
   }
 
   private async handleKillSessionAction(step: TestStep): Promise<void> {

--- a/src/agents/WebSocketAgent.ts
+++ b/src/agents/WebSocketAgent.ts
@@ -569,7 +569,7 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
           break;
           
         case 'add_listener':
-          this.addEventListener(step.target, step.value);
+          this.addEventListener(step.target);
           result = true;
           break;
           
@@ -930,7 +930,7 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
            this.connectionInfo?.state === ConnectionState.CONNECTED;
   }
 
-  private addEventListener(event: string, handlerStr?: string): void {
+  private addEventListener(event: string): void {
     const handler = (data: any) => {
       this.logger.debug(`Event received: ${event}`, { data });
     };
@@ -1049,11 +1049,11 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
   }
 
   private generateConnectionId(): string {
-    return `conn_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `conn_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
   }
 
   private generateMessageId(): string {
-    return `msg_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
   }
 
   private applyEnvironmentConfig(environment: Record<string, string>): void {
@@ -1076,7 +1076,11 @@ export class WebSocketAgent extends EventEmitter implements IAgent {
   }
 
   private getScenarioLogs(): string[] {
-    return this.logger ? ['No scenario-specific logs available'] : [];
+    return this.messageHistory.map(msg => {
+      const dir = msg.direction === 'sent' ? 'SENT' : 'RECV';
+      const data = typeof msg.data === 'string' ? msg.data : JSON.stringify(msg.data);
+      return `[${msg.timestamp.toISOString()}] [${dir}] ${msg.event}: ${data}`;
+    });
   }
 
   private setupEventListeners(): void {

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -85,10 +85,9 @@ export type {
   APIResponse,
   RequestPerformance
 } from './APIAgent';
-export { WebSocketAgent, createWebSocketAgent } from './WebSocketAgent';
+export { WebSocketAgent, createWebSocketAgent, ConnectionState } from './WebSocketAgent';
 export type {
   WebSocketAgentConfig,
-  ConnectionState,
   WebSocketMessage,
   ConnectionMetrics,
   LatencyMeasurement,


### PR DESCRIPTION
## Summary

Fixes issue #99 by addressing 8 quality issues across 5 agent files:

- **IssueReporter** - MD5 → SHA-256 for stack trace hashing (security improvement)
- **IssueReporter** - Rate limit wait capped at 60s; throws instead of blocking indefinitely
- **WebSocketAgent** - `getScenarioLogs()` now returns real message history (was always `['No scenario-specific logs available']`)
- **APIAgent** - `getScenarioLogs()` now returns real request/response log entries (was always `['No scenario-specific logs available']`)
- **APIAgent** - `clear_cookies` stub removed; falls through to `Unsupported API action` error (no cookie support in Axios)
- **TUIAgent** - `handleResizeTerminalAction` now throws `resize_terminal action is not yet implemented` instead of silently updating state without effect
- **WebSocketAgent** - `addEventListener` `handlerStr` parameter removed (it was always ignored)
- **5 files** - All `.toString(36).substr(2, 9)` replaced with `.toString(36).slice(2, 11)` (`.substr` is deprecated)
- **agents/index.ts** - `ConnectionState` exported as a value (`export { ConnectionState }`) not a type, so enum members are usable at runtime

## Test plan

- [x] `npx tsc --noEmit` - compiles cleanly with zero errors
- [x] `npx jest --no-coverage --forceExit` - 327 tests pass; 14 failures are all pre-existing (ZombieProcessPrevention flaky env test, terminal.integration octal escape TS error, SystemAgent.test.ts timeout issues, tests/TUIAgent.test.ts mock import issue)
- [x] No regressions introduced by these changes

Closes #99

Generated with [Claude Code](https://claude.com/claude-code)