### PR TITLE
fix: rename archiveRun to exportManifest, use deterministic scenario IDs (#108)

### DIFF
--- a/src/__tests__/scenarioAdapter.test.ts
+++ b/src/__tests__/scenarioAdapter.test.ts
@@ -19,10 +19,29 @@ describe('scenarioAdapter', () => {
   });
 
   describe('adaptScenarioToComplex', () => {
-    it('should produce a ComplexScenario with a UUID id', () => {
+    it('should produce a deterministic id from the scenario name', () => {
       const result = adaptScenarioToComplex(makeScenario());
 
+      expect(result.id).toBe('scenario-test-scenario');
+    });
+
+    it('should produce the same id on repeated calls with the same name', () => {
+      const a = adaptScenarioToComplex(makeScenario({ name: 'My Scenario' }));
+      const b = adaptScenarioToComplex(makeScenario({ name: 'My Scenario' }));
+
+      expect(a.id).toBe(b.id);
+    });
+
+    it('should fall back to a UUID when no name is provided', () => {
+      const result = adaptScenarioToComplex(makeScenario({ name: undefined }));
+
       expect(result.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    });
+
+    it('should slugify special characters in names', () => {
+      const result = adaptScenarioToComplex(makeScenario({ name: 'My Test: Scenario #1!' }));
+
+      expect(result.id).toBe('scenario-my-test-scenario-1');
     });
 
     it('should carry over name and description', () => {

--- a/src/adapters/scenarioAdapter.ts
+++ b/src/adapters/scenarioAdapter.ts
@@ -29,8 +29,15 @@ export function adaptScenarioToComplex(simple: SimpleScenario): ComplexScenario 
     ? simple.cleanup.map(adaptStepToOrchestrator)
     : undefined;
 
+  // Build a deterministic ID from the scenario name so that repeated calls
+  // with the same scenario produce the same ID (stable across test runs and
+  // diffing). Fall back to a random UUID only when no name is provided.
+  const id = simple.name
+    ? `scenario-${simple.name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')}`
+    : uuidv4();
+
   return {
-    id: uuidv4(),
+    id,
     name: simple.name || 'Unnamed scenario',
     description: simple.description || `Test scenario: ${simple.name || 'unnamed'}`,
     priority: mapPriority(simple.metadata?.priority),

--- a/src/utils/screenshot/ScreenshotReporter.ts
+++ b/src/utils/screenshot/ScreenshotReporter.ts
@@ -1,7 +1,7 @@
 /**
  * ScreenshotReporter - Reporting and persistence
  *
- * generateComparisonReport, archiveRun, exportMetadata
+ * generateComparisonReport, exportManifest, exportMetadata
  */
 
 import * as fs from 'fs/promises';
@@ -63,18 +63,22 @@ export class ScreenshotReporter {
   }
 
   /**
-   * Archive screenshots for a completed run
+   * Export a JSON manifest of all screenshots captured in this run.
+   *
+   * Previously misnamed `archiveRun`, which implied a .tar.gz archive that was
+   * never created. The method has always written a JSON file; this rename and
+   * the corrected default path make the behaviour explicit.
    */
-  async archiveRun(archivePath?: string): Promise<string> {
-    const finalArchivePath =
-      archivePath ||
+  async exportManifest(manifestPath?: string): Promise<string> {
+    const finalManifestPath =
+      manifestPath ||
       path.join(
         this.organizationOptions.baseDir,
-        'archives',
-        `${this.runId}.tar.gz`
+        'manifests',
+        `${this.runId}.json`
       );
 
-    await this.ensureDirectoryExists(path.dirname(finalArchivePath));
+    await this.ensureDirectoryExists(path.dirname(finalManifestPath));
 
     const runScreenshots = Array.from(this.metadata.values());
     const manifest = {
@@ -84,12 +88,9 @@ export class ScreenshotReporter {
       totalCount: runScreenshots.length,
     };
 
-    await fs.writeFile(
-      finalArchivePath.replace('.tar.gz', '.json'),
-      JSON.stringify(manifest, null, 2)
-    );
+    await fs.writeFile(finalManifestPath, JSON.stringify(manifest, null, 2));
 
-    return finalArchivePath;
+    return finalManifestPath;
   }
 
   /**

--- a/src/utils/screenshot/index.ts
+++ b/src/utils/screenshot/index.ts
@@ -70,7 +70,9 @@ export class ScreenshotManager {
 
   // -- Reporting delegation --
   generateComparisonReport(results: Array<ComparisonResult & { name: string }>, outputPath?: string): Promise<string> { return this.reporter.generateComparisonReport(results, outputPath); }
-  archiveRun(archivePath?: string): Promise<string> { return this.reporter.archiveRun(archivePath); }
+  exportManifest(manifestPath?: string): Promise<string> { return this.reporter.exportManifest(manifestPath); }
+  /** @deprecated Use exportManifest instead */
+  archiveRun(manifestPath?: string): Promise<string> { return this.reporter.exportManifest(manifestPath); }
   exportMetadata(filePath?: string): Promise<string> { return this.reporter.exportMetadata(filePath); }
 
   // -- Query methods --


### PR DESCRIPTION
## Summary

- **Fix 1 (ScreenshotReporter)**: Rename `archiveRun()` to `exportManifest()` (Option A — simpler). The method was writing a `.json` file but using a `.tar.gz` path and returning the wrong path. The new name and default path (`manifests/<runId>.json`) accurately describe what the code does. A deprecated `archiveRun()` shim is retained on `ScreenshotManager` for backward compatibility.
- **Fix 2 (scenarioAdapter)**: Replace the random `uuidv4()` call with a deterministic slug derived from the scenario name — `scenario-<slugified-name>`. Falls back to `uuidv4()` only when no name is present. Repeated calls with the same scenario now produce the same ID, making test output and diffs stable.
- **Tests**: `scenarioAdapter.test.ts` updated to assert the new deterministic ID format, stability across repeated calls, special-character slugification, and UUID fallback for unnamed scenarios (40 tests, all passing).

## Files changed

- `src/utils/screenshot/ScreenshotReporter.ts` — rename `archiveRun` → `exportManifest`, fix default path and returned path
- `src/utils/screenshot/index.ts` — expose new `exportManifest` method, keep deprecated `archiveRun` shim
- `src/adapters/scenarioAdapter.ts` — deterministic ID generation
- `src/__tests__/scenarioAdapter.test.ts` — updated + 3 new tests for deterministic IDs

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npx jest src/__tests__/scenarioAdapter.test.ts --no-coverage --forceExit` — 40/40 pass
- [x] Full `npx jest --no-coverage --forceExit` — all `src/__tests__/` suites pass; 2 pre-existing failures in `tests/` (unrelated octal-escape and `promisify` issues, also failing on `main`)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)