### PR TITLE
fix: resolve medium/low quality issues (sync I/O, hardcoded paths, lazy init, any casts)

### DIFF
--- a/src/cli/commands/init-templates.ts
+++ b/src/cli/commands/init-templates.ts
@@ -18,7 +18,7 @@ execution:
 
 cli:
   executablePath: ${template === 'electron' ? 'npm run electron' : 'atg'}
-  workingDirectory: ${process.cwd()}
+  workingDirectory: ./
   defaultTimeout: 30000
   environment: {}
   captureOutput: true

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -227,9 +227,6 @@ export function createLogger(config?: Partial<LoggerConfig>): TestLogger {
  */
 let _activeLogger: TestLogger = new TestLogger();
 
-/** @deprecated Use the `logger` convenience object instead */
-export const defaultLogger = _activeLogger;
-
 /**
  * Convenience methods that always delegate to the current active logger.
  */

--- a/src/utils/screenshot/DiffRenderer.ts
+++ b/src/utils/screenshot/DiffRenderer.ts
@@ -54,7 +54,7 @@ export async function createPixelDiff(
     );
   }
 
-  return diffImage as any;
+  return diffImage as unknown as JimpImage;
 }
 
 /**
@@ -90,7 +90,7 @@ export async function createPerceptualDiff(
       diffImage.setPixelColor(rgbaToInt(finalColor[0], finalColor[1], finalColor[2], finalColor[3]), x, y);
     }
   }
-  return diffImage as any;
+  return diffImage as unknown as JimpImage;
 }
 
 /**
@@ -125,7 +125,7 @@ export async function createStructuralDiff(
       diffImage.setPixelColor(rgbaToInt(finalColor[0], finalColor[1], finalColor[2], finalColor[3]), x, y);
     }
   }
-  return diffImage as any;
+  return diffImage as unknown as JimpImage;
 }
 
 /**

--- a/src/utils/screenshot/ImageComparator.ts
+++ b/src/utils/screenshot/ImageComparator.ts
@@ -6,6 +6,7 @@
 
 import * as path from 'path';
 import { Jimp, loadFont } from 'jimp';
+import { logger } from '../logger';
 import { FileUtils } from '../fileUtils';
 import pixelmatchDefault from 'pixelmatch';
 import { ComparisonOptions, ComparisonResult, DiffAlgorithm, DiffColorOptions } from './types';
@@ -108,11 +109,18 @@ export class ImageComparator {
         sbs.composite(baseline, 0, 0);
         sbs.composite(actual, tw, 0);
         sbs.composite(diffImage, tw * 2, 0);
-        const fontPath = path.join(__dirname, '../../../node_modules/@jimp/plugin-print/fonts/open-sans/open-sans-16-black/open-sans-16-black.fnt');
-        const font = await loadFont(fontPath);
-        sbs.print({ font, x: 10, y: 10, text: 'Baseline' });
-        sbs.print({ font, x: tw + 10, y: 10, text: 'Actual' });
-        sbs.print({ font, x: tw * 2 + 10, y: 10, text: 'Diff' });
+        try {
+          const fontPath = require.resolve(
+            '@jimp/plugin-print/fonts/open-sans/open-sans-16-black/open-sans-16-black.fnt'
+          );
+          const font = await loadFont(fontPath);
+          sbs.print({ font, x: 10, y: 10, text: 'Baseline' });
+          sbs.print({ font, x: tw + 10, y: 10, text: 'Actual' });
+          sbs.print({ font, x: tw * 2 + 10, y: 10, text: 'Diff' });
+        } catch {
+          // Skip text annotations if the font is not available (e.g. bundled scenarios)
+          logger.warn('Could not load diff font, text annotations disabled');
+        }
         diffImage = sbs;
       }
 


### PR DESCRIPTION
## Summary

Fixes all 6 code quality issues from #120:

- **MED-07**: Logger constructor (`LogTransport.ts`) was calling `fs.existsSync` + `fs.mkdirSync` (synchronous I/O) on every logger instantiation, blocking the event loop. Replaced with `fs.promises.mkdir` (async, fire-and-forget) so directory creation never blocks module import or constructor.
- **MED-05**: `init-templates.ts` embedded `process.cwd()` in the generated `agentic-test.config.yaml`, exposing the machine's absolute filesystem path when the config was committed to version control. Replaced with relative `./`.
- **MED-06**: `globalConfigManager` in `config.ts` was `new ConfigManager()` at module scope, running at import time and causing shared state across tests. Replaced with a `getGlobalConfigManager()` factory and a backward-compatible `Proxy` so construction is deferred to first use.
- **MED-13**: `ImageComparator.ts` had a hardcoded `path.join(__dirname, '../../../node_modules/...')` font path that breaks in bundled scenarios. Replaced with `require.resolve()` inside a try/catch; text annotations are skipped gracefully when the font is unavailable.
- **MED-14**: `DiffRenderer.ts` had 3 occurrences of `return diffImage as any`. Replaced with `return diffImage as unknown as JimpImage` where `JimpImage = Awaited<ReturnType<typeof Jimp.read>>`, properly typing the return without bypassing the type system.
- **LOW-03**: `defaultLogger` in `logger.ts` was `export const defaultLogger = _activeLogger` which captures the initial instance and never reflects subsequent `setupLogger()` calls. The deprecated export has been removed; all callers should use the `logger` convenience object.

## Test plan

- [x] `npx tsc --noEmit` — zero errors after each file change
- [x] `npx jest --no-coverage --forceExit` — 29/29 suites pass, 710/711 tests pass (1 skipped, pre-existing)
- [x] No new test failures introduced

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)