### PR TITLE
[WS-A] fix: event listener leaks, console.log in lib, broken gadugi-smart-test bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
   },
   "bin": {
     "gadugi-test": "./dist/cli.js",
-    "gadugi-smart-test": "./dist/runners/SmartUITestRunner.js"
+    "gadugi-smart-test": "./dist/runners/smart-cli.js"
   },
   "scripts": {
     "build": "tsc --skipLibCheck --noEmitOnError false && npm run postbuild",
-    "postbuild": "chmod +x dist/cli.js dist/runners/SmartUITestRunner.js 2>/dev/null || true",
+    "postbuild": "chmod +x dist/cli.js dist/runners/smart-cli.js 2>/dev/null || true",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "jest",

--- a/src/__tests__/critical-bugs.test.ts
+++ b/src/__tests__/critical-bugs.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for three critical bugs (issue #126):
+ *   A1a: ResourceOptimizer.destroy() must remove all sub-optimizer listeners
+ *   A1b: PtyTerminal.destroy() must remove processManager listeners
+ *   A1c: TUIAgent.cleanup() must remove the error handler registered in constructor
+ *   A2:  ResultsHandler must not call console.log (library layer)
+ *   A3:  gadugi-smart-test bin target must be a real CLI entry point
+ */
+
+import { EventEmitter } from 'events';
+import { ProcessLifecycleManager } from '../core/ProcessLifecycleManager';
+import { PtyTerminal } from '../core/PtyTerminal';
+import { ResourceOptimizer } from '../core/ResourceOptimizer';
+import { displayResults, performDryRun } from '../lib/ResultsHandler';
+import { TUIAgent } from '../agents/TUIAgent';
+
+// ---------------------------------------------------------------------------
+// A1a: ResourceOptimizer listener cleanup
+// ---------------------------------------------------------------------------
+describe('A1a: ResourceOptimizer.destroy() removes sub-optimizer listeners', () => {
+  it('should have no sub-optimizer forwarding listeners after destroy()', async () => {
+    const pm = {
+      on: jest.fn(),
+      emit: jest.fn(),
+      startProcess: jest.fn(),
+      killProcess: jest.fn(),
+      shutdown: jest.fn().mockResolvedValue(undefined),
+    } as unknown as ProcessLifecycleManager;
+
+    const optimizer = new ResourceOptimizer(
+      { enableMetrics: true, enableGarbageCollection: false },
+      pm
+    );
+
+    const internal = optimizer as any;
+    const memoryOpt: EventEmitter = internal.memoryOpt;
+    const cpuOpt: EventEmitter = internal.cpuOpt;
+    const concurrencyOpt: EventEmitter = internal.concurrencyOpt;
+
+    // All three should have listeners registered before destroy
+    expect(
+      memoryOpt.listenerCount('memoryWarning') +
+      memoryOpt.listenerCount('memoryAlert') +
+      memoryOpt.listenerCount('gcTriggered') +
+      memoryOpt.listenerCount('error')
+    ).toBeGreaterThan(0);
+
+    await optimizer.destroy();
+
+    // After destroy, sub-optimizers must have no forwarding listeners
+    expect(memoryOpt.listenerCount('memoryWarning')).toBe(0);
+    expect(memoryOpt.listenerCount('memoryAlert')).toBe(0);
+    expect(memoryOpt.listenerCount('gcTriggered')).toBe(0);
+    expect(memoryOpt.listenerCount('error')).toBe(0);
+    expect(cpuOpt.listenerCount('bufferRotated')).toBe(0);
+    expect(concurrencyOpt.listenerCount('resourceCreated')).toBe(0);
+    expect(concurrencyOpt.listenerCount('resourceDestroyed')).toBe(0);
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// A1b: PtyTerminal listener cleanup
+// ---------------------------------------------------------------------------
+describe('A1b: PtyTerminal.destroy() removes processManager listeners', () => {
+  it('should remove all listeners from processManager during destroy()', async () => {
+    const pm = new ProcessLifecycleManager();
+    const terminal = new PtyTerminal({}, pm);
+
+    // PtyTerminal.setupProcessManagerEvents registers 2 listeners
+    expect(pm.listenerCount('processExited') + pm.listenerCount('error')).toBeGreaterThan(0);
+
+    await terminal.destroy();
+    await pm.shutdown();
+
+    // After destroy, no listeners should remain on the processManager
+    expect(pm.listenerCount('processExited')).toBe(0);
+    expect(pm.listenerCount('error')).toBe(0);
+
+    pm.destroy();
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// A1c: TUIAgent cleanup removes error handler
+// ---------------------------------------------------------------------------
+describe('A1c: TUIAgent.cleanup() removes error handler registered in constructor', () => {
+  it('should remove the error listener added in the constructor', async () => {
+    const agent = new TUIAgent({});
+
+    // Constructor registers exactly 1 error listener
+    expect(agent.listenerCount('error')).toBe(1);
+
+    await agent.cleanup();
+
+    // After cleanup, the constructor error listener must be removed
+    expect(agent.listenerCount('error')).toBe(0);
+  }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// A2: ResultsHandler uses logger, not console.log
+//
+// Strategy: use jest.doMock (not hoisted) within an isolated test context so
+// we can verify that logger.info is called without affecting the module-level
+// imports that other tests depend on (TUIAgent, ResourceOptimizer, etc.).
+// ---------------------------------------------------------------------------
+describe('A2: ResultsHandler uses logger.info, not console.log', () => {
+  let displayResultsFn: (session: any) => void;
+  let performDryRunFn: (scenarios: any[], suite: string) => Promise<void>;
+  let loggerInfoMock: jest.Mock;
+
+  beforeAll(async () => {
+    // Set up the mock in an isolated module registry
+    jest.isolateModules(() => {
+      loggerInfoMock = jest.fn();
+      jest.doMock('../utils/logger', () => ({
+        logger: {
+          info: loggerInfoMock,
+          warn: jest.fn(),
+          error: jest.fn(),
+          debug: jest.fn(),
+        },
+        createLogger: jest.fn(() => ({
+          info: jest.fn(),
+          warn: jest.fn(),
+          error: jest.fn(),
+          debug: jest.fn(),
+          setContext: jest.fn(),
+          scenarioStart: jest.fn(),
+          scenarioEnd: jest.fn(),
+        })),
+      }));
+      // Must use require inside isolateModules
+      const mod = require('../lib/ResultsHandler');
+      displayResultsFn = mod.displayResults;
+      performDryRunFn = mod.performDryRun;
+    });
+  });
+
+  beforeEach(() => {
+    loggerInfoMock.mockClear();
+  });
+
+  it('displayResults calls logger.info with session summary', () => {
+    const session = {
+      id: 'test-session',
+      startTime: new Date('2026-01-01T00:00:00Z'),
+      endTime: new Date('2026-01-01T00:01:00Z'),
+      summary: { total: 10, passed: 8, failed: 1, skipped: 1 },
+      results: [],
+    };
+
+    displayResultsFn(session as any);
+
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'TEST SESSION RESULTS',
+      expect.objectContaining({
+        sessionId: 'test-session',
+        total: 10,
+        passed: 8,
+        failed: 1,
+      })
+    );
+  });
+
+  it('performDryRun calls logger.info with scenario count', async () => {
+    await performDryRunFn([], 'smoke');
+
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'DRY RUN MODE - Not executing tests',
+      expect.objectContaining({ suite: 'smoke', scenarioCount: 0 })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// A3: smart-cli.ts exists and is a proper module
+// ---------------------------------------------------------------------------
+describe('A3: gadugi-smart-test has a valid CLI entry point', () => {
+  it('src/runners/smart-cli.ts must export a runSmartUITests function', async () => {
+    // We cannot import it directly since it requires electron, but we can
+    // verify the file exists and the module exports the right shape by
+    // checking via the filesystem
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const filePath = path.resolve(__dirname, '../runners/smart-cli.ts');
+    // The file must exist
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+
+  it('package.json bin.gadugi-smart-test must point to dist/runners/smart-cli.js', async () => {
+    const fs = await import('fs/promises');
+    const path = await import('path');
+    const pkgPath = path.resolve(__dirname, '../../package.json'); // two levels up from src/__tests__
+    const content = await fs.readFile(pkgPath, 'utf-8');
+    const pkg = JSON.parse(content);
+    expect(pkg.bin['gadugi-smart-test']).toBe('./dist/runners/smart-cli.js');
+  });
+});

--- a/src/core/PtyTerminal.ts
+++ b/src/core/PtyTerminal.ts
@@ -326,6 +326,11 @@ export class PtyTerminal extends EventEmitter {
 
     this.isDestroyed = true;
 
+    // Remove listeners registered in setupProcessManagerEvents() to prevent
+    // dangling references after this terminal is destroyed.
+    this.processManager.removeAllListeners('processExited');
+    this.processManager.removeAllListeners('error');
+
     try {
       // Kill the process if it's running
       if (this.isRunning()) {

--- a/src/core/ResourceOptimizer.ts
+++ b/src/core/ResourceOptimizer.ts
@@ -176,6 +176,12 @@ export class ResourceOptimizer extends EventEmitter {
     if (this.isDestroying) return;
     this.isDestroying = true;
 
+    // Remove all forwarding listeners before stopping sub-optimizers to
+    // prevent dangling references and MaxListenersExceededWarning on reuse.
+    this.memoryOpt.removeAllListeners();
+    this.cpuOpt.removeAllListeners();
+    this.concurrencyOpt.removeAllListeners();
+
     this.memoryOpt.stop();
     this.cpuOpt.stop();
 

--- a/src/runners/smart-cli.ts
+++ b/src/runners/smart-cli.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * smart-cli.ts
+ *
+ * CLI entry point for the Smart UI Test Runner.
+ * Exposed as the `gadugi-smart-test` binary in package.json.
+ *
+ * Usage:
+ *   gadugi-smart-test [--screenshots-dir <path>]
+ */
+
+import { Command } from 'commander';
+import { runSmartUITests } from './SmartUITestRunner';
+import { TestStatus } from '../models/TestModels';
+
+const program = new Command();
+
+program
+  .name('gadugi-smart-test')
+  .description('Smart UI testing agent — discovers and exercises Electron app tabs automatically')
+  .option('--screenshots-dir <path>', 'directory for captured screenshots', 'screenshots')
+  .action(async (options: { screenshotsDir: string }) => {
+    try {
+      const result = await runSmartUITests(options.screenshotsDir);
+      process.exitCode = result.status === TestStatus.PASSED ? 0 : 1;
+    } catch (err) {
+      process.stderr.write(`Smart UI test failed: ${(err as Error).message}\n`);
+      process.exitCode = 1;
+    }
+  });
+
+// Only execute when invoked as a CLI binary, not when required as a module.
+if (require.main === module) {
+  program.parseAsync(process.argv).catch((err: Error) => {
+    process.stderr.write(`Unexpected error: ${err.message}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Fixes three critical bugs identified in issue #126.

### A1: Memory leaks from unbalanced EventEmitters

**ResourceOptimizer.destroy()** (`src/core/ResourceOptimizer.ts`): Added `removeAllListeners()` calls on `memoryOpt`, `cpuOpt`, and `concurrencyOpt` before stopping them. Previously 7 forwarding listeners registered in the constructor were never removed.

**PtyTerminal.destroy()** (`src/core/PtyTerminal.ts`): Added `processManager.removeAllListeners('processExited')` and `processManager.removeAllListeners('error')` at the start of `destroy()`. Previously the 2 listeners registered in `setupProcessManagerEvents()` leaked on every terminal destruction.

**TUIAgent.cleanup()** (`src/agents/TUIAgent.ts`): Stored the `error` handler registered in the constructor as `this.errorHandler`, then calls `this.removeListener('error', this.errorHandler)` in `cleanup()`. Previously the constructor-registered listener was never removed.

### A2: ResultsHandler console.log in library layer

Replaced all 15 `console.log` calls in `src/lib/ResultsHandler.ts` with `logger.info()` calls using the structured logger. The library layer must not assume console availability or format — callers control log output.

### A3: Broken gadugi-smart-test bin target

Created `src/runners/smart-cli.ts` as a proper Commander CLI entry point that calls `runSmartUITests()`. Updated `package.json` `bin` and `postbuild` script to reference `./dist/runners/smart-cli.js`. The file uses `require.main === module` guard to prevent auto-execution on `require()`.

### Tests

Added `src/__tests__/critical-bugs.test.ts` with 7 targeted regression tests:
- A1a: Verifies listener counts on sub-optimizers are 0 after `ResourceOptimizer.destroy()`
- A1b: Verifies listener counts on processManager are 0 after `PtyTerminal.destroy()`
- A1c: Verifies `TUIAgent.listenerCount('error')` is 0 after `cleanup()`
- A2: Verifies `logger.info` is called (not `console.log`) in `displayResults` and `performDryRun`
- A3: Verifies `smart-cli.ts` exists and `package.json` bin points to correct path

## Test plan

- [ ] All 7 new tests in `critical-bugs.test.ts` pass
- [ ] `ResourceOptimizer.test.ts` (22 tests) passes without regressions
- [ ] `TUIAgent` tests (112 tests) pass without regressions
- [ ] `npx tsc --noEmit` reports no errors
- [ ] `SystemAgent.basic.test.ts` failure is pre-existing (confirmed on main), not introduced by this PR

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)