### PR TITLE
fix: resolve 3 post-workstream test regressions (#142)

### DIFF
--- a/src/agents/TUIAgent.ts
+++ b/src/agents/TUIAgent.ts
@@ -78,7 +78,9 @@ export class TUIAgent extends BaseAgent {
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       this.logger.error('Failed to initialize TUIAgent', { error: message });
-      throw new Error(`Failed to initialize TUIAgent: ${message}`);
+      // Re-throw the original error so callers can match its message directly
+      // (e.g. tests checking for "Working directory does not exist").
+      throw error instanceof Error ? error : new Error(message);
     }
   }
 

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -40,15 +40,17 @@ import {
 export async function validateDirectory(dirPath: string): Promise<void> {
   try {
     await fsPromises.access(dirPath);
-    const stats = await fsPromises.stat(dirPath);
-    if (!stats.isDirectory()) {
-      throw new Error(`Working directory is not a directory: ${dirPath}`);
-    }
   } catch (error: unknown) {
-    if (error instanceof Error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+    // In some environments (e.g. Jest/ts-jest sandboxed VM) Node's native
+    // errors fail `instanceof Error`, so check `.code` directly.
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       throw new Error(`Working directory does not exist: ${dirPath}`);
     }
     throw error;
+  }
+  const stats = await fsPromises.stat(dirPath);
+  if (!stats.isDirectory()) {
+    throw new Error(`Working directory is not a directory: ${dirPath}`);
   }
 }
 import { readJsonFile, exists, getMetadata } from './files/FileReader';


### PR DESCRIPTION
## Summary

Fixes 3 test regressions introduced after recent workstream PRs merged to main (closes #142).

- **fileUtils.ts**: Remove `instanceof Error` guard from ENOENT check in `validateDirectory()`. In the Jest/ts-jest sandbox VM, Node native errors fail `instanceof Error` due to cross-realm identity, so the descriptive message was never thrown and the raw ENOENT propagated. Also split `access()` and `stat()` into separate try/catch blocks to prevent the "not a directory" Error from being caught by the ENOENT handler.
- **TUIAgent.ts**: Re-throw the original Error from `initialize()` instead of wrapping it. Tests matching `/Working directory does not exist/` were failing because the message was buried inside `"Failed to initialize TUIAgent: Error: Working directory does not exist: ..."`.
- **SystemAgent.basic.test.ts**: Switch the metrics-history test from a fixed 2500ms sleep to an event-driven `agent.on('metrics', ...)` pattern. `captureMetrics()` enumerates all system processes via `pidusage` and can take longer than the 1000ms monitoring interval, making the time-based wait unreliable and resulting in `history.length === 0`.

## Test plan

- [x] `npx jest src/__tests__/validateDirectory.test.ts --no-coverage --forceExit` — 3/3 pass
- [x] `npx jest tests/TUIAgent.lifecycle.test.ts --no-coverage --forceExit` — 29/29 pass
- [x] `npx jest src/agents/__tests__/SystemAgent.basic.test.ts --no-coverage --forceExit` — 25/25 pass
- [x] Full suite `npx jest --no-coverage --forceExit --runInBand` — 52 suites, 972 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)