### PR TITLE
[WS-COV-2] test: file utility sub-module tests

### DIFF
--- a/src/__tests__/files/FileArchiver.test.ts
+++ b/src/__tests__/files/FileArchiver.test.ts
@@ -1,0 +1,326 @@
+/**
+ * FileArchiver tests — fs/promises and glob are mocked.
+ *
+ * Coverage targets:
+ *   copy          — file copy
+ *   backup        — timestamped backup
+ *   cleanup       — pattern-based deletion + path-traversal guard
+ *   sync          — source → destination sync
+ */
+
+// ---------- mock glob before importing ----------
+const mockGlob = jest.fn();
+jest.mock('glob', () => ({ glob: (...args: unknown[]) => mockGlob(...args) }));
+
+// ---------- mock fs/promises ----------
+const mockStat = jest.fn();
+const mockMkdir = jest.fn();
+const mockWriteFile = jest.fn();
+const mockAppendFile = jest.fn();
+const mockCopyFile = jest.fn();
+const mockRename = jest.fn();
+const mockRm = jest.fn();
+const mockRmdir = jest.fn();
+const mockUnlink = jest.fn();
+const mockReaddir = jest.fn();
+const mockAccess = jest.fn();
+
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  default: {
+    stat: (...args: unknown[]) => mockStat(...args),
+    mkdir: (...args: unknown[]) => mockMkdir(...args),
+    writeFile: (...args: unknown[]) => mockWriteFile(...args),
+    appendFile: (...args: unknown[]) => mockAppendFile(...args),
+    copyFile: (...args: unknown[]) => mockCopyFile(...args),
+    rename: (...args: unknown[]) => mockRename(...args),
+    rm: (...args: unknown[]) => mockRm(...args),
+    rmdir: (...args: unknown[]) => mockRmdir(...args),
+    unlink: (...args: unknown[]) => mockUnlink(...args),
+    readdir: (...args: unknown[]) => mockReaddir(...args),
+    access: (...args: unknown[]) => mockAccess(...args),
+  }
+}));
+
+// ---------- mock crypto (used transitively by FileSearch.calculateHash) ----------
+const mockDigest = jest.fn(() => 'abc123');
+const mockUpdate = jest.fn(() => ({ digest: mockDigest }));
+jest.mock('crypto', () => ({
+  __esModule: true,
+  default: { createHash: jest.fn(() => ({ update: mockUpdate })) },
+}));
+
+import path from 'path';
+import {
+  copy,
+  backup,
+  cleanup,
+  sync,
+} from '../../utils/files/FileArchiver';
+import { FileOperationError } from '../../utils/files/types';
+
+// ---------------------------------------------------------------------------
+
+function makeFileStats(overrides: { size?: number; mtime?: Date } = {}) {
+  return {
+    isDirectory: () => false,
+    isFile: () => true,
+    size: overrides.size ?? 512,
+    mtime: overrides.mtime ?? new Date('2024-01-01'),
+    birthtime: new Date('2024-01-01'),
+    mode: 0o100644,
+  };
+}
+
+function makeDirStats() {
+  return {
+    isDirectory: () => true,
+    isFile: () => false,
+    size: 4096,
+    mtime: new Date('2024-01-01'),
+    birthtime: new Date('2024-01-01'),
+    mode: 0o040755,
+  };
+}
+
+function makeEnoent(): NodeJS.ErrnoException {
+  const err = new Error('ENOENT') as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return err;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ===========================================================================
+// copy
+// ===========================================================================
+describe('copy', () => {
+  it('copies a file to the destination', async () => {
+    // ensureDirectory: stat says parent dir exists
+    mockStat
+      .mockResolvedValueOnce(makeDirStats())   // ensureDirectory: stat parent of dst
+      .mockResolvedValueOnce(makeFileStats()); // copy: stat source
+
+    mockCopyFile.mockResolvedValue(undefined);
+
+    await copy('/src/file.txt', '/dst/file.txt');
+
+    expect(mockCopyFile).toHaveBeenCalledWith('/src/file.txt', '/dst/file.txt');
+  });
+
+  it('throws FileOperationError when source stat fails', async () => {
+    mockStat
+      .mockResolvedValueOnce(makeDirStats()) // ensureDirectory parent dir
+      .mockRejectedValueOnce(new Error('ENOENT')); // source stat fails
+
+    await expect(copy('/missing/file.txt', '/dst/file.txt')).rejects.toThrow(FileOperationError);
+  });
+
+  it('throws FileOperationError when destination exists and overwrite=false', async () => {
+    mockStat
+      .mockResolvedValueOnce(makeDirStats())   // ensureDirectory parent
+      .mockResolvedValueOnce(makeFileStats()); // source stat
+
+    // exists() uses access — returns successfully meaning dest exists
+    mockAccess.mockResolvedValue(undefined);
+
+    await expect(copy('/src/file.txt', '/dst/file.txt', false)).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// backup
+// ===========================================================================
+describe('backup', () => {
+  it('creates a timestamped backup copy and returns the backup path', async () => {
+    // Multiple stat calls:
+    // 1. ensureDirectory for backupDir → ENOENT → mkdir
+    // 2. ensureDirectory for copy destination parent → already handled by backup
+    // 3. copy's ensureDirectory for backup parent
+    // 4. stat of source inside copy
+    mockStat
+      .mockRejectedValueOnce(makeEnoent())    // ensureDirectory(backupDir): ENOENT
+      .mockResolvedValueOnce(makeDirStats())  // ensureDirectory inside copy
+      .mockResolvedValueOnce(makeFileStats()); // source stat inside copy
+
+    mockMkdir.mockResolvedValue(undefined);
+    mockCopyFile.mockResolvedValue(undefined);
+
+    const backupPath = await backup('/data/config.yaml', '/backups');
+
+    expect(backupPath).toMatch(/\/backups\/config\.yaml\.backup\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/);
+    expect(mockCopyFile).toHaveBeenCalled();
+  });
+
+  it('uses a sibling "backups" directory when no backupDir is provided', async () => {
+    mockStat
+      .mockRejectedValueOnce(makeEnoent())
+      .mockResolvedValueOnce(makeDirStats())
+      .mockResolvedValueOnce(makeFileStats());
+
+    mockMkdir.mockResolvedValue(undefined);
+    mockCopyFile.mockResolvedValue(undefined);
+
+    const backupPath = await backup('/data/config.yaml');
+
+    expect(backupPath).toContain('/data/backups/');
+  });
+});
+
+// ===========================================================================
+// cleanup
+// ===========================================================================
+describe('cleanup', () => {
+  it('deletes files matching includePatterns', async () => {
+    // exists() for the directory
+    mockAccess.mockResolvedValue(undefined);
+
+    // findFiles (glob) returns two log files
+    mockGlob.mockResolvedValue([
+      '/work/app.log',
+      '/work/debug.log',
+    ]);
+
+    mockStat.mockResolvedValue(makeFileStats({ size: 256 }));
+    mockUnlink.mockResolvedValue(undefined);
+
+    const result = await cleanup('/work', { includePatterns: ['*.log'] });
+
+    expect(result.deletedFiles).toHaveLength(2);
+    expect(result.errors).toHaveLength(0);
+    expect(result.totalSize).toBe(512); // 2 × 256
+  });
+
+  it('blocks path-traversal patterns (../../ paths rejected)', async () => {
+    // exists() passes
+    mockAccess.mockResolvedValue(undefined);
+
+    // glob returns a path that resolves OUTSIDE /work
+    const traversalPath = path.resolve('/work/../../secrets/key.pem');
+    mockGlob.mockResolvedValue([traversalPath]);
+
+    // stat would only be called for safe paths; should NOT be called
+    mockStat.mockResolvedValue(makeFileStats());
+    mockUnlink.mockResolvedValue(undefined);
+
+    const result = await cleanup('/work');
+
+    // The traversal path must be silently filtered — nothing deleted
+    expect(result.deletedFiles).toHaveLength(0);
+    expect(mockUnlink).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty result when the directory does not exist', async () => {
+    mockAccess.mockRejectedValue(makeEnoent());
+
+    const result = await cleanup('/nonexistent');
+
+    expect(result.deletedFiles).toHaveLength(0);
+    expect(result.deletedDirectories).toHaveLength(0);
+    expect(result.totalSize).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('respects dryRun option — does not actually delete files', async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockGlob.mockResolvedValue(['/work/old.log']);
+    mockStat.mockResolvedValue(makeFileStats({ size: 100 }));
+
+    const result = await cleanup('/work', { dryRun: true });
+
+    expect(result.deletedFiles).toHaveLength(1);
+    expect(mockUnlink).not.toHaveBeenCalled();
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+
+  it('records errors without throwing when a single file deletion fails', async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockGlob.mockResolvedValue(['/work/locked.log']);
+    mockStat.mockResolvedValueOnce(makeFileStats({ size: 100 }));
+    mockUnlink.mockRejectedValue(new Error('EACCES'));
+
+    // deleteFileOrDir calls stat again inside it
+    mockStat.mockResolvedValue(makeFileStats({ size: 100 }));
+
+    const result = await cleanup('/work');
+
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+// sync
+// ===========================================================================
+describe('sync', () => {
+  it('copies files from source to destination', async () => {
+    // ensureDirectory for destination
+    mockStat
+      .mockResolvedValueOnce(makeDirStats());    // ensureDirectory dest
+
+    // findFiles returns relative paths
+    mockGlob.mockResolvedValueOnce(['file.ts']); // source files
+
+    // exists() for dest file → ENOENT (does not exist yet)
+    mockAccess.mockRejectedValue(makeEnoent());
+
+    // copy: ensureDirectory parent + stat source
+    mockStat
+      .mockResolvedValueOnce(makeDirStats())    // ensureDirectory inside copy
+      .mockResolvedValueOnce(makeFileStats());  // stat source
+
+    mockCopyFile.mockResolvedValue(undefined);
+
+    const result = await sync('/src', '/dst');
+
+    expect(result.copied).toContain('file.ts');
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('updates a file when source is newer than destination', async () => {
+    const oldMtime = new Date('2024-01-01');
+    const newMtime = new Date('2024-06-01');
+
+    // ensureDirectory dest
+    mockStat.mockResolvedValueOnce(makeDirStats());
+
+    mockGlob.mockResolvedValueOnce(['config.json']);
+
+    // exists() dest → true
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    // stat source and stat dest for mtime comparison
+    mockStat
+      .mockResolvedValueOnce(makeFileStats({ mtime: newMtime })) // source
+      .mockResolvedValueOnce(makeFileStats({ mtime: oldMtime })) // dest
+      // copy: ensureDirectory parent
+      .mockResolvedValueOnce(makeDirStats())
+      // copy: stat source again
+      .mockResolvedValueOnce(makeFileStats({ mtime: newMtime }));
+
+    mockCopyFile.mockResolvedValue(undefined);
+
+    const result = await sync('/src', '/dst');
+
+    expect(result.updated).toContain('config.json');
+  });
+
+  it('does not update a file when destination is up to date', async () => {
+    const sameMtime = new Date('2024-06-01');
+
+    mockStat.mockResolvedValueOnce(makeDirStats());  // ensureDirectory
+    mockGlob.mockResolvedValueOnce(['config.json']);
+    mockAccess.mockResolvedValueOnce(undefined);     // dest exists
+
+    mockStat
+      .mockResolvedValueOnce(makeFileStats({ mtime: sameMtime }))  // source
+      .mockResolvedValueOnce(makeFileStats({ mtime: sameMtime })); // dest — same time
+
+    const result = await sync('/src', '/dst');
+
+    expect(result.updated).toHaveLength(0);
+    expect(result.copied).toHaveLength(0);
+    expect(mockCopyFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/files/FileReader.test.ts
+++ b/src/__tests__/files/FileReader.test.ts
@@ -1,0 +1,190 @@
+/**
+ * FileReader tests — all fs/promises calls are mocked.
+ *
+ * Coverage targets:
+ *   readJsonFile
+ *   exists
+ *   getMetadata
+ */
+
+import path from 'path';
+
+// ---------- mock fs/promises before importing the module under test ----------
+const mockReadFile = jest.fn();
+const mockAccess = jest.fn();
+const mockStat = jest.fn();
+
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  default: {
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+    access: (...args: unknown[]) => mockAccess(...args),
+    stat: (...args: unknown[]) => mockStat(...args),
+  }
+}));
+
+import {
+  readJsonFile,
+  exists,
+  getMetadata,
+} from '../../utils/files/FileReader';
+import { FileOperationError } from '../../utils/files/types';
+
+// ---------------------------------------------------------------------------
+
+function makeStats(overrides: {
+  isDirectory?: boolean;
+  size?: number;
+  mtime?: Date;
+  birthtime?: Date;
+  mode?: number;
+} = {}) {
+  return {
+    isDirectory: () => overrides.isDirectory ?? false,
+    isFile: () => !(overrides.isDirectory ?? false),
+    size: overrides.size ?? 1024,
+    mtime: overrides.mtime ?? new Date('2024-06-01T12:00:00Z'),
+    birthtime: overrides.birthtime ?? new Date('2024-01-01T00:00:00Z'),
+    mode: overrides.mode ?? 0o100644,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ===========================================================================
+// readJsonFile
+// ===========================================================================
+describe('readJsonFile', () => {
+  it('reads and parses a valid JSON file', async () => {
+    const data = { foo: 'bar', count: 3 };
+    mockReadFile.mockResolvedValue(JSON.stringify(data));
+
+    const result = await readJsonFile<typeof data>('/some/file.json');
+
+    expect(result).toEqual(data);
+    expect(mockReadFile).toHaveBeenCalledWith('/some/file.json', 'utf-8');
+  });
+
+  it('throws FileOperationError when file cannot be read', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(readJsonFile('/missing/file.json')).rejects.toThrow(FileOperationError);
+  });
+
+  it('throws FileOperationError when content is invalid JSON', async () => {
+    mockReadFile.mockResolvedValue('not valid json {{{');
+
+    await expect(readJsonFile('/bad/file.json')).rejects.toThrow(FileOperationError);
+  });
+
+  it('returns an empty object for an empty JSON object file', async () => {
+    mockReadFile.mockResolvedValue('{}');
+
+    const result = await readJsonFile('/empty/object.json');
+
+    expect(result).toEqual({});
+  });
+
+  it('returns a typed result using the generic parameter', async () => {
+    const arr = [1, 2, 3];
+    mockReadFile.mockResolvedValue(JSON.stringify(arr));
+
+    const result = await readJsonFile<number[]>('/array.json');
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([1, 2, 3]);
+  });
+});
+
+// ===========================================================================
+// exists
+// ===========================================================================
+describe('exists', () => {
+  it('returns true when fs.access resolves (file exists)', async () => {
+    mockAccess.mockResolvedValue(undefined);
+
+    const result = await exists('/existing/file.txt');
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when fs.access throws (file does not exist)', async () => {
+    const err = new Error('ENOENT') as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    mockAccess.mockRejectedValue(err);
+
+    const result = await exists('/missing/file.txt');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for any access error (e.g. permission denied)', async () => {
+    const err = new Error('EACCES') as NodeJS.ErrnoException;
+    err.code = 'EACCES';
+    mockAccess.mockRejectedValue(err);
+
+    const result = await exists('/locked/file.txt');
+
+    expect(result).toBe(false);
+  });
+});
+
+// ===========================================================================
+// getMetadata
+// ===========================================================================
+describe('getMetadata', () => {
+  it('returns correct metadata for a regular file', async () => {
+    const mtime = new Date('2024-06-15T10:00:00Z');
+    const birthtime = new Date('2024-01-10T08:00:00Z');
+    mockStat.mockResolvedValue(makeStats({
+      isDirectory: false,
+      size: 2048,
+      mtime,
+      birthtime,
+      mode: 0o100644,
+    }));
+
+    const meta = await getMetadata('/data/report.json');
+
+    expect(meta.filePath).toBe('/data/report.json');
+    expect(meta.fileName).toBe('report.json');
+    expect(meta.extension).toBe('.json');
+    expect(meta.size).toBe(2048);
+    expect(meta.modifiedAt).toEqual(mtime);
+    expect(meta.createdAt).toEqual(birthtime);
+    expect(meta.isDirectory).toBe(false);
+    expect(meta.permissions).toBe('644');
+  });
+
+  it('returns correct metadata for a directory', async () => {
+    mockStat.mockResolvedValue(makeStats({
+      isDirectory: true,
+      size: 4096,
+      mode: 0o040755,
+    }));
+
+    const meta = await getMetadata('/data/subdir');
+
+    expect(meta.isDirectory).toBe(true);
+    expect(meta.fileName).toBe('subdir');
+    expect(meta.extension).toBe('');
+    expect(meta.size).toBe(4096);
+    expect(meta.permissions).toBe('755');
+  });
+
+  it('lowercases the extension', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: false }));
+
+    const meta = await getMetadata('/data/IMAGE.PNG');
+
+    expect(meta.extension).toBe('.png');
+  });
+
+  it('throws FileOperationError when stat fails', async () => {
+    mockStat.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(getMetadata('/missing/file.txt')).rejects.toThrow(FileOperationError);
+  });
+});

--- a/src/__tests__/files/FileSearch.test.ts
+++ b/src/__tests__/files/FileSearch.test.ts
@@ -1,0 +1,260 @@
+/**
+ * FileSearch tests — glob, fs/promises and crypto are mocked.
+ *
+ * Coverage targets:
+ *   findFiles
+ *   calculateHash
+ *   filterByAge
+ *   filterByPatterns  (include mode, exclude mode, ReDoS safety)
+ */
+
+// ---------- mock 'glob' before importing the module under test ----------
+const mockGlob = jest.fn();
+jest.mock('glob', () => ({ glob: (...args: unknown[]) => mockGlob(...args) }));
+
+// ---------- mock fs/promises ----------
+const mockReadFile = jest.fn();
+const mockFsStat = jest.fn();
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  default: {
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+    stat: (...args: unknown[]) => mockFsStat(...args),
+  }
+}));
+
+// ---------- mock crypto (for deterministic hash testing) ----------
+const mockDigest = jest.fn();
+const mockUpdate = jest.fn(() => ({ digest: mockDigest }));
+const mockCreateHash = jest.fn(() => ({ update: mockUpdate }));
+jest.mock('crypto', () => ({
+  __esModule: true,
+  default: { createHash: (...args: unknown[]) => mockCreateHash(...args) },
+}));
+
+import {
+  findFiles,
+  calculateHash,
+  filterByAge,
+  filterByPatterns,
+} from '../../utils/files/FileSearch';
+import { FileOperationError } from '../../utils/files/types';
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ===========================================================================
+// findFiles
+// ===========================================================================
+describe('findFiles', () => {
+  it('returns matching paths for a single string pattern', async () => {
+    mockGlob.mockResolvedValue(['/project/src/a.ts', '/project/src/b.ts']);
+
+    const result = await findFiles('**/*.ts', { cwd: '/project' });
+
+    expect(mockGlob).toHaveBeenCalledWith('**/*.ts', expect.objectContaining({ cwd: '/project' }));
+    expect(result).toEqual(['/project/src/a.ts', '/project/src/b.ts']);
+  });
+
+  it('returns matching paths for an array of patterns', async () => {
+    mockGlob
+      .mockResolvedValueOnce(['/project/a.ts'])
+      .mockResolvedValueOnce(['/project/b.js']);
+
+    const result = await findFiles(['**/*.ts', '**/*.js'], { cwd: '/project' });
+
+    expect(mockGlob).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(['/project/a.ts', '/project/b.js']);
+  });
+
+  it('deduplicates results when the same path appears in multiple patterns', async () => {
+    mockGlob
+      .mockResolvedValueOnce(['/project/shared.ts'])
+      .mockResolvedValueOnce(['/project/shared.ts', '/project/other.ts']);
+
+    const result = await findFiles(['**/*.ts', 'src/**/*.ts'], { cwd: '/project' });
+
+    expect(result).toEqual(['/project/shared.ts', '/project/other.ts']);
+  });
+
+  it('passes absolute=true by default', async () => {
+    mockGlob.mockResolvedValue([]);
+
+    await findFiles('**/*');
+
+    expect(mockGlob).toHaveBeenCalledWith('**/*', expect.objectContaining({ absolute: true }));
+  });
+
+  it('passes ignore option when provided', async () => {
+    mockGlob.mockResolvedValue([]);
+
+    await findFiles('**/*.ts', { ignore: ['node_modules/**'] });
+
+    expect(mockGlob).toHaveBeenCalledWith('**/*.ts', expect.objectContaining({ ignore: ['node_modules/**'] }));
+  });
+
+  it('throws FileOperationError when glob throws', async () => {
+    mockGlob.mockRejectedValue(new Error('glob error'));
+
+    await expect(findFiles('**/*.ts')).rejects.toThrow(FileOperationError);
+  });
+
+  it('returns an empty array when no files match', async () => {
+    mockGlob.mockResolvedValue([]);
+
+    const result = await findFiles('**/*.xyz');
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// calculateHash
+// ===========================================================================
+describe('calculateHash', () => {
+  it('returns a consistent sha256 hex string for file content', async () => {
+    const fakeBuffer = Buffer.from('hello world');
+    mockReadFile.mockResolvedValue(fakeBuffer);
+    mockDigest.mockReturnValue('aabbccddeeff0011');
+
+    const result = await calculateHash('/some/file.txt', 'sha256');
+
+    expect(mockCreateHash).toHaveBeenCalledWith('sha256');
+    expect(mockUpdate).toHaveBeenCalledWith(fakeBuffer);
+    expect(mockDigest).toHaveBeenCalledWith('hex');
+    expect(result).toBe('aabbccddeeff0011');
+  });
+
+  it('uses md5 as default algorithm', async () => {
+    mockReadFile.mockResolvedValue(Buffer.from('data'));
+    mockDigest.mockReturnValue('deadbeef');
+
+    await calculateHash('/file.bin');
+
+    expect(mockCreateHash).toHaveBeenCalledWith('md5');
+  });
+
+  it('throws FileOperationError when file cannot be read', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(calculateHash('/missing/file.txt')).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// filterByAge
+// ===========================================================================
+describe('filterByAge', () => {
+  it('includes files newer than the cutoff time', async () => {
+    const now = Date.now();
+    const recentMtime = new Date(now - 1000);    // 1 second ago
+    const oldMtime = new Date(now - 60_000);     // 1 minute ago
+    const cutoff = now - 30_000;                 // 30 seconds ago
+
+    mockFsStat
+      .mockResolvedValueOnce({ mtime: recentMtime })   // /recent.log — newer than cutoff (NOT in result)
+      .mockResolvedValueOnce({ mtime: oldMtime });     // /old.log    — older than cutoff (in result)
+
+    const result = await filterByAge(['/recent.log', '/old.log'], cutoff);
+
+    // filterByAge keeps files where mtime < cutoffTime (i.e. older files)
+    expect(result).toEqual(['/old.log']);
+  });
+
+  it('excludes files newer than maxAgeMs cutoff', async () => {
+    const now = Date.now();
+    const futureMtime = new Date(now + 5000);
+    const cutoff = now;
+
+    mockFsStat.mockResolvedValue({ mtime: futureMtime });
+
+    const result = await filterByAge(['/new-file.log'], cutoff);
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when no files are provided', async () => {
+    const result = await filterByAge([], Date.now());
+
+    expect(result).toEqual([]);
+    expect(mockFsStat).not.toHaveBeenCalled();
+  });
+
+  it('silently skips files that cannot be stat-ed', async () => {
+    mockFsStat.mockRejectedValue(new Error('ENOENT'));
+
+    const result = await filterByAge(['/ghost.log'], 0);
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ===========================================================================
+// filterByPatterns
+// ===========================================================================
+describe('filterByPatterns — include mode (exclude=false)', () => {
+  it('returns only files matching the pattern', () => {
+    const files = ['/tmp/app.log', '/tmp/debug.log', '/tmp/data.csv'];
+    const result = filterByPatterns(files, ['*.log'], false);
+
+    expect(result).toEqual(['/tmp/app.log', '/tmp/debug.log']);
+  });
+
+  it('returns an empty array when no files match', () => {
+    const files = ['/tmp/data.csv', '/tmp/report.txt'];
+    const result = filterByPatterns(files, ['*.log'], false);
+
+    expect(result).toEqual([]);
+  });
+
+  it('matches against the file name portion only (not full path)', () => {
+    const files = ['/var/log/system.log'];
+    const result = filterByPatterns(files, ['system.log'], false);
+
+    expect(result).toEqual(['/var/log/system.log']);
+  });
+});
+
+describe('filterByPatterns — exclude mode (exclude=true)', () => {
+  it('returns files NOT matching the exclude pattern', () => {
+    const files = ['/tmp/app.log', '/tmp/debug.log', '/tmp/data.csv'];
+    const result = filterByPatterns(files, ['*.log'], true);
+
+    expect(result).toEqual(['/tmp/data.csv']);
+  });
+
+  it('returns all files when nothing matches the exclude pattern', () => {
+    const files = ['/tmp/a.txt', '/tmp/b.txt'];
+    const result = filterByPatterns(files, ['*.log'], true);
+
+    expect(result).toEqual(['/tmp/a.txt', '/tmp/b.txt']);
+  });
+
+  it('returns an empty array when all files match the exclude pattern', () => {
+    const files = ['/tmp/app.log', '/tmp/debug.log'];
+    const result = filterByPatterns(files, ['*.log'], true);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('filterByPatterns — ReDoS safety', () => {
+  it('does NOT cause catastrophic backtracking on a ReDoS-prone input', () => {
+    // Pattern `(a+)+` — when passed raw to RegExp, it would cause exponential
+    // backtracking on input like 'aaaaaaaaaaaX'. globToRegex must escape it.
+    const files = ['(a+)+', 'aaaaaaaaaaaaaaaaaaaaX'];
+
+    const start = Date.now();
+    // Should complete well within 500 ms because metacharacters are escaped
+    const result = filterByPatterns(files, ['(a+)+'], false);
+    const elapsed = Date.now() - start;
+
+    // The function should return results
+    expect(Array.isArray(result)).toBe(true);
+    // And it should NOT take more than 500 ms
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/src/__tests__/files/FileWriter.test.ts
+++ b/src/__tests__/files/FileWriter.test.ts
@@ -1,0 +1,393 @@
+/**
+ * FileWriter tests — all fs/promises calls are mocked.
+ *
+ * Coverage targets:
+ *   writeFile       (via appendToFile public surface)
+ *   appendToFile
+ *   writeJsonFile
+ *   ensureDirectory
+ *   move
+ *   deleteFileOrDir
+ *   createTempFile
+ *   createTempDirectory
+ *   removeEmptyDirectories
+ */
+
+import path from 'path';
+
+// ---------- mock fs/promises before importing the module under test ----------
+const mockStat = jest.fn();
+const mockMkdir = jest.fn();
+const mockWriteFile = jest.fn();
+const mockAppendFile = jest.fn();
+const mockRename = jest.fn();
+const mockRm = jest.fn();
+const mockRmdir = jest.fn();
+const mockUnlink = jest.fn();
+const mockReaddir = jest.fn();
+const mockCopyFile = jest.fn();
+
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  default: {
+    stat: (...args: unknown[]) => mockStat(...args),
+    mkdir: (...args: unknown[]) => mockMkdir(...args),
+    writeFile: (...args: unknown[]) => mockWriteFile(...args),
+    appendFile: (...args: unknown[]) => mockAppendFile(...args),
+    rename: (...args: unknown[]) => mockRename(...args),
+    rm: (...args: unknown[]) => mockRm(...args),
+    rmdir: (...args: unknown[]) => mockRmdir(...args),
+    unlink: (...args: unknown[]) => mockUnlink(...args),
+    readdir: (...args: unknown[]) => mockReaddir(...args),
+    copyFile: (...args: unknown[]) => mockCopyFile(...args),
+  }
+}));
+
+import {
+  ensureDirectory,
+  writeJsonFile,
+  appendToFile,
+  move,
+  deleteFileOrDir,
+  createTempFile,
+  createTempDirectory,
+  removeEmptyDirectories,
+} from '../../utils/files/FileWriter';
+import { FileOperationError } from '../../utils/files/types';
+
+// ---------------------------------------------------------------------------
+
+function makeStats(overrides: Partial<{ isDirectory: boolean; size: number; mtime: Date }> = {}) {
+  return {
+    isDirectory: () => overrides.isDirectory ?? false,
+    isFile: () => !(overrides.isDirectory ?? false),
+    size: overrides.size ?? 100,
+    mtime: overrides.mtime ?? new Date('2024-01-01'),
+    birthtime: new Date('2024-01-01'),
+    mode: 0o100644,
+  };
+}
+
+function makeEnoent(): NodeJS.ErrnoException {
+  const err = new Error('ENOENT') as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return err;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ===========================================================================
+// ensureDirectory
+// ===========================================================================
+describe('ensureDirectory', () => {
+  it('is a no-op when the directory already exists', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+
+    await ensureDirectory('/existing/dir');
+
+    expect(mockStat).toHaveBeenCalledWith('/existing/dir');
+    expect(mockMkdir).not.toHaveBeenCalled();
+  });
+
+  it('creates the directory (recursively) when it does not exist', async () => {
+    mockStat.mockRejectedValue(makeEnoent());
+    mockMkdir.mockResolvedValue(undefined);
+
+    await ensureDirectory('/new/dir');
+
+    expect(mockMkdir).toHaveBeenCalledWith('/new/dir', { recursive: true });
+  });
+
+  it('throws FileOperationError when path exists but is not a directory', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: false }));
+
+    await expect(ensureDirectory('/existing/file')).rejects.toThrow(FileOperationError);
+  });
+
+  it('throws FileOperationError when mkdir fails', async () => {
+    mockStat.mockRejectedValue(makeEnoent());
+    mockMkdir.mockRejectedValue(new Error('Permission denied'));
+
+    await expect(ensureDirectory('/protected/dir')).rejects.toThrow(FileOperationError);
+  });
+
+  it('throws FileOperationError for non-ENOENT stat errors', async () => {
+    const err = new Error('EACCES') as NodeJS.ErrnoException;
+    err.code = 'EACCES';
+    mockStat.mockRejectedValue(err);
+
+    await expect(ensureDirectory('/locked/dir')).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// writeJsonFile
+// ===========================================================================
+describe('writeJsonFile', () => {
+  beforeEach(() => {
+    // ensureDirectory will call stat then (if ENOENT) mkdir
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+    mockWriteFile.mockResolvedValue(undefined);
+  });
+
+  it('writes JSON content to the file', async () => {
+    const data = { key: 'value', num: 42 };
+
+    await writeJsonFile('/some/dir/file.json', data);
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/some/dir/file.json',
+      expect.any(String),
+      'utf-8'
+    );
+    const written = mockWriteFile.mock.calls[0][1] as string;
+    expect(JSON.parse(written)).toEqual(data);
+  });
+
+  it('uses 2-space indentation when pretty=true (default)', async () => {
+    const data = { a: 1 };
+
+    await writeJsonFile('/out/file.json', data, true);
+
+    const written = mockWriteFile.mock.calls[0][1] as string;
+    expect(written).toBe(JSON.stringify(data, null, 2));
+  });
+
+  it('produces compact JSON when pretty=false', async () => {
+    const data = { a: 1 };
+
+    await writeJsonFile('/out/file.json', data, false);
+
+    const written = mockWriteFile.mock.calls[0][1] as string;
+    expect(written).toBe(JSON.stringify(data));
+  });
+
+  it('throws FileOperationError when writeFile fails', async () => {
+    mockWriteFile.mockRejectedValue(new Error('disk full'));
+
+    await expect(writeJsonFile('/out/file.json', {})).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// appendToFile
+// ===========================================================================
+describe('appendToFile', () => {
+  it('appends content to an existing file', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+    mockAppendFile.mockResolvedValue(undefined);
+
+    await appendToFile('/some/dir/log.txt', 'new line\n');
+
+    expect(mockAppendFile).toHaveBeenCalledWith('/some/dir/log.txt', 'new line\n');
+  });
+
+  it('creates and appends to a new file (directory must exist)', async () => {
+    mockStat.mockRejectedValue(makeEnoent());
+    mockMkdir.mockResolvedValue(undefined);
+    mockAppendFile.mockResolvedValue(undefined);
+
+    await appendToFile('/new/dir/log.txt', 'first line\n');
+
+    expect(mockMkdir).toHaveBeenCalled();
+    expect(mockAppendFile).toHaveBeenCalledWith('/new/dir/log.txt', 'first line\n');
+  });
+
+  it('throws FileOperationError when appendFile fails', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+    mockAppendFile.mockRejectedValue(new Error('EROFS'));
+
+    await expect(appendToFile('/ro/file.txt', 'data')).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// move
+// ===========================================================================
+describe('move', () => {
+  it('renames the file to the destination', async () => {
+    // ensureDirectory for destination parent
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+    mockRename.mockResolvedValue(undefined);
+
+    await move('/src/file.txt', '/dst/file.txt');
+
+    expect(mockRename).toHaveBeenCalledWith('/src/file.txt', '/dst/file.txt');
+  });
+
+  it('throws FileOperationError when rename fails', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+    mockRename.mockRejectedValue(new Error('EXDEV'));
+
+    await expect(move('/src/file.txt', '/dst/file.txt')).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// deleteFileOrDir
+// ===========================================================================
+describe('deleteFileOrDir', () => {
+  it('deletes a regular file', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: false }));
+    mockUnlink.mockResolvedValue(undefined);
+
+    await deleteFileOrDir('/path/to/file.txt');
+
+    expect(mockUnlink).toHaveBeenCalledWith('/path/to/file.txt');
+  });
+
+  it('deletes a directory recursively when recursive=true', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+    mockRm.mockResolvedValue(undefined);
+
+    await deleteFileOrDir('/path/to/dir', true);
+
+    expect(mockRm).toHaveBeenCalledWith('/path/to/dir', { recursive: true, force: true });
+  });
+
+  it('deletes an empty directory when recursive=false', async () => {
+    mockStat.mockResolvedValue(makeStats({ isDirectory: true }));
+    mockRmdir.mockResolvedValue(undefined);
+
+    await deleteFileOrDir('/path/to/dir', false);
+
+    expect(mockRmdir).toHaveBeenCalledWith('/path/to/dir');
+  });
+
+  it('silently ignores ENOENT (file not found)', async () => {
+    mockStat.mockRejectedValue(makeEnoent());
+
+    await expect(deleteFileOrDir('/non/existent/file.txt')).resolves.toBeUndefined();
+  });
+
+  it('throws FileOperationError for non-ENOENT errors', async () => {
+    const err = new Error('EACCES') as NodeJS.ErrnoException;
+    err.code = 'EACCES';
+    mockStat.mockRejectedValue(err);
+
+    await expect(deleteFileOrDir('/locked/file.txt')).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// createTempFile
+// ===========================================================================
+describe('createTempFile', () => {
+  it('creates a temp file in the system temp directory and returns its path', async () => {
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const tmpDir = process.env.TMPDIR || process.env.TMP || '/tmp';
+    const result = await createTempFile('test', '.tmp');
+
+    expect(result).toMatch(new RegExp(`^${tmpDir.replace(/\\/g, '\\\\')}`));
+    expect(result).toMatch(/test_\d+_[a-z0-9]+\.tmp$/);
+    expect(mockWriteFile).toHaveBeenCalledWith(result, '');
+  });
+
+  it('uses default prefix and suffix when none provided', async () => {
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const result = await createTempFile();
+
+    expect(result).toMatch(/temp_\d+_[a-z0-9]+\.tmp$/);
+  });
+
+  it('throws FileOperationError when writeFile fails', async () => {
+    mockWriteFile.mockRejectedValue(new Error('ENOSPC'));
+
+    await expect(createTempFile()).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// createTempDirectory
+// ===========================================================================
+describe('createTempDirectory', () => {
+  it('creates a temp directory and returns its path', async () => {
+    // ensureDirectory inside createTempDirectory: stat throws ENOENT → mkdir succeeds
+    mockStat.mockRejectedValue(makeEnoent());
+    mockMkdir.mockResolvedValue(undefined);
+
+    const tmpDir = process.env.TMPDIR || process.env.TMP || '/tmp';
+    const result = await createTempDirectory('myprefix');
+
+    expect(result).toMatch(new RegExp(`^${tmpDir.replace(/\\/g, '\\\\')}`));
+    expect(result).toMatch(/myprefix_\d+_[a-z0-9]+$/);
+    expect(mockMkdir).toHaveBeenCalled();
+  });
+
+  it('uses default prefix when none provided', async () => {
+    mockStat.mockRejectedValue(makeEnoent());
+    mockMkdir.mockResolvedValue(undefined);
+
+    const result = await createTempDirectory();
+
+    expect(result).toMatch(/temp_\d+_[a-z0-9]+$/);
+  });
+
+  it('throws FileOperationError when mkdir fails', async () => {
+    mockStat.mockRejectedValue(makeEnoent());
+    mockMkdir.mockRejectedValue(new Error('ENOSPC'));
+
+    await expect(createTempDirectory()).rejects.toThrow(FileOperationError);
+  });
+});
+
+// ===========================================================================
+// removeEmptyDirectories
+// ===========================================================================
+describe('removeEmptyDirectories', () => {
+  it('removes a subdirectory that becomes empty after recursion', async () => {
+    // directory contains one subdir ('sub') which is itself empty
+    mockReaddir
+      .mockResolvedValueOnce(['sub'])           // top-level readdir
+      .mockResolvedValueOnce([])                // readdir for 'sub' (empty) — recursion
+      .mockResolvedValueOnce([]);               // re-check 'sub' is empty
+
+    const subPath = path.join('/parent', 'sub');
+    mockStat.mockImplementation((p: string) => {
+      if (p === subPath) return Promise.resolve(makeStats({ isDirectory: true }));
+      return Promise.reject(makeEnoent());
+    });
+    mockRmdir.mockResolvedValue(undefined);
+
+    await removeEmptyDirectories('/parent');
+
+    expect(mockRmdir).toHaveBeenCalledWith(subPath);
+  });
+
+  it('skips a non-empty subdirectory', async () => {
+    // directory contains one subdir ('sub') which has a file inside
+    mockReaddir
+      .mockResolvedValueOnce(['sub'])          // top-level readdir
+      .mockResolvedValueOnce(['file.txt'])     // readdir for 'sub' — recursion
+      .mockResolvedValueOnce(['file.txt']);    // re-check 'sub' — still has a file
+
+    const subPath = path.join('/parent', 'sub');
+    mockStat.mockImplementation((p: string) => {
+      if (p === subPath) return Promise.resolve(makeStats({ isDirectory: true }));
+      return Promise.reject(makeEnoent());
+    });
+
+    await removeEmptyDirectories('/parent');
+
+    expect(mockRmdir).not.toHaveBeenCalled();
+  });
+
+  it('silently ignores errors during cleanup', async () => {
+    mockReaddir.mockRejectedValue(new Error('EACCES'));
+
+    // Should not throw
+    await expect(removeEmptyDirectories('/locked')).resolves.toBeUndefined();
+  });
+
+  it('does nothing when directory is empty (no items to recurse into)', async () => {
+    mockReaddir.mockResolvedValue([]);
+
+    await removeEmptyDirectories('/empty');
+
+    expect(mockRmdir).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 75 new unit tests across 4 new test files covering `src/utils/files/` sub-modules
- All `fs/promises`, `glob`, and `crypto` calls are fully mocked — tests run in < 2 s, no disk I/O
- Closes #147

### Files added

| Test file | Source file | Key scenarios covered |
|-----------|-------------|----------------------|
| `src/__tests__/files/FileWriter.test.ts` | `FileWriter.ts` | `ensureDirectory` (exists/ENOENT/error), `writeJsonFile` (pretty/compact), `appendToFile`, `move`, `deleteFileOrDir` (file/dir/recursive/ENOENT), `createTempFile`, `createTempDirectory`, `removeEmptyDirectories` |
| `src/__tests__/files/FileReader.test.ts` | `FileReader.ts` | `readJsonFile` (valid/invalid JSON), `exists` (true/false/any error), `getMetadata` (file/dir/error) |
| `src/__tests__/files/FileSearch.test.ts` | `FileSearch.ts` | `findFiles` (single/array/dedup/ignore), `calculateHash` (sha256/md5), `filterByAge` (include/exclude/skip inaccessible), `filterByPatterns` (include/exclude/ReDoS safety) |
| `src/__tests__/files/FileArchiver.test.ts` | `FileArchiver.ts` | `copy` (file/error/overwrite=false), `backup` (timestamped/default dir), `cleanup` (delete/path-traversal guard/dryRun/errors), `sync` (copy/update/no-op) |

## Test plan

- [x] `npx jest src/__tests__/files/ --no-coverage --forceExit --runInBand` — 75/75 pass
- [x] Full suite (`src/__tests__/`) — 541 tests pass, 31 suites pass
- [x] No new test imports stubs or real file I/O
- [x] ReDoS safety test verifies `filterByPatterns` completes in < 500 ms on a pathological `(a+)+` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)