### PR TITLE
[WS-DOCS-1] docs: update CHANGELOG and ARCHITECTURE for post-v1.0 improvements

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Complete documentation for the Gadugi multi-agent testing framework.
 
 ## Reference
 
-- [Architecture](./ARCHITECTURE.md) - Layered architecture, all modules, BaseAgent pattern, and data flow
+- [Architecture](./ARCHITECTURE.md) - Layered architecture, all modules, BaseAgent and IPipelineAgent patterns, IAgent registry, and data flow
 - [API Reference](../API_REFERENCE.md) - Programmatic API (`lib.ts`) and exported types
 - [CLI Reference](../README.md) - `gadugi-test` command-line options
 - [YAML Scenario Schema](../scenarios/README.md) - All scenario fields, agent types, and action names


### PR DESCRIPTION
## Summary

Closes #166

Updates `CHANGELOG.md` and `docs/ARCHITECTURE.md` to reflect all improvements merged after v1.0.0 (18 commits, PRs #128–#161).

### CHANGELOG.md — new `[Unreleased]` section

**Added**
- `IPipelineAgent` interface (`src/agents/index.ts`) — marker interface for non-execution pipeline agents
- `validate_schema` step action — real ajv@8 implementation replacing stub in `APIResponseValidator`
- `src/cli/setup.ts` — `setupGracefulShutdown` relocated from public lib API
- `closeAfterEachScenario` config on `ElectronUIAgentConfig`

**Changed**
- `ScenarioRouter` IAgent registry (`Partial<Record<TestInterface, IAgent>>`): decoupled from concrete agent classes
- `TestInterface.API` now routes to `APIAgent` (was silently dropped to `CLIAgent`)
- `filterScenariosForSuite()` deduplicated to canonical implementation in `ScenarioLoader`
- `catch(error: any)` → `catch(error: unknown)` across 23 files
- `any` type count reduced from 140 → ~120 in `src/`
- Dead exports and side-effecting `loadFromEnv()` call removed
- `console.log` → `process.stdout.write` in runners (programmatic API callers)

**Fixed**
- Event listener leaks in `ResourceOptimizer`, `PtyTerminal`, `TUIAgent`
- `ResultsHandler` using `console.log` in programmatic API
- `gadugi-smart-test` bin broken after module split
- `ZombieProcessPrevention` parallel test flakiness

**Tests**
- 700+ new tests documented across 14 workstream PRs
- New test files for WebSocket sub-modules (126), CLI commands, ElectronUIAgent sub-modules (73), file utils (75)

### docs/ARCHITECTURE.md — updated 2026-02-24

- Agent Layer: documents `IAgent` vs `IPipelineAgent` distinction with interface definitions
- New **IPipelineAgent Pattern** section with table of pipeline agents and custom agent example
- **ScenarioRouter**: clarifies IAgent registry pattern, API routing fix, explicit failure on unregistered types
- **CLI**: documents `cli/setup.ts` and `setupGracefulShutdown` relocation
- **Utils**: adds `ids.ts` and `colors.ts` to shared helpers table
- **Programmatic API**: notes `setupGracefulShutdown` moved to `cli/setup.ts`

### docs/index.md

- Architecture entry updated to mention IPipelineAgent and IAgent registry sections

## Test plan

- [x] `npx jest --no-coverage --forceExit --testPathPattern="config|retry|comparison"` — 128/128 pass
- [x] Docs-only changes; no TypeScript source modified
- [x] All doc files remain in `docs/` directory and linked from `docs/index.md`
- [x] No temporal information (status, test results) included in docs
- [x] CHANGELOG follows Keep a Changelog format with correct sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)