### PR TITLE
fix: resolve 5 ESLint errors (prefer-const, no-var-requires)

### DIFF
--- a/src/__tests__/orchestrator/TestOrchestrator.integration.test.ts
+++ b/src/__tests__/orchestrator/TestOrchestrator.integration.test.ts
@@ -72,7 +72,7 @@ function makeAgent() {
   };
 }
 
-let mockSessionId = 'session-001';
+const mockSessionId = 'session-001';
 
 const mockSessionInstance = {
   create:      jest.fn(() => ({ id: mockSessionId, status: TestStatus.RUNNING, results: [], summary: {} } as unknown as TestSession)),

--- a/src/core/optimizer/CpuOptimizer.ts
+++ b/src/core/optimizer/CpuOptimizer.ts
@@ -154,7 +154,7 @@ export class CpuOptimizer extends EventEmitter {
   }
 
   private compressBuffer(buffer: Buffer): Buffer {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const zlib = require('zlib') as typeof import('zlib');
     try {
       return zlib.gzipSync(buffer);
@@ -164,7 +164,7 @@ export class CpuOptimizer extends EventEmitter {
   }
 
   private decompressBuffer(buffer: Buffer): Buffer {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const zlib = require('zlib') as typeof import('zlib');
     try {
       return zlib.gunzipSync(buffer);

--- a/src/runners/ComprehensiveUITestRunner.ts
+++ b/src/runners/ComprehensiveUITestRunner.ts
@@ -42,7 +42,7 @@ export class ComprehensiveUITestRunner {
     await fs.mkdir(this.screenshotsDir, { recursive: true });
     this.tester.logInfo('Launching Electron application...');
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const electronPath = require('electron') as string;
     const appPath = path.resolve(process.cwd(), '..');
 

--- a/src/runners/SmartUITestRunner.ts
+++ b/src/runners/SmartUITestRunner.ts
@@ -78,7 +78,7 @@ export class SmartUITestRunner {
     this.log('cyan', '🎯', 'Testing the UI by discovering and using actual features\n');
     this.log('blue', '🚀', 'Launching application...');
 
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const electronPath = require('electron') as string;
     const appPath = path.resolve(process.cwd(), '..');
 


### PR DESCRIPTION
## Summary

Fixes 5 ESLint errors across 4 files. Zero new logic - pure lint suppressions and one variable declaration fix.

- **prefer-const** (1 error): `let mockSessionId` -> `const mockSessionId` in `TestOrchestrator.integration.test.ts:75` - variable is never reassigned
- **@typescript-eslint/no-var-requires** (4 errors): Existing `// eslint-disable-next-line` comments named the wrong rule (`no-require-imports` instead of `no-var-requires`). Added the correct rule name to the existing comment on the same line:
  - `CpuOptimizer.ts` lines 158, 168 - dynamic `require('zlib')` inside private methods (lazy-loaded for optional compression)
  - `ComprehensiveUITestRunner.ts` line 46 - `require('electron')` for Playwright Electron launch (cannot be top-level import)
  - `SmartUITestRunner.ts` line 82 - same pattern as above

## Test plan

- [x] `npx eslint src/ 2>&1 | grep " error " | wc -l` returns `0`
- [x] `npx tsc --noEmit` exits clean
- [x] `npx jest --no-coverage --forceExit --runInBand --testPathPattern="TestOrchestrator.integration"` - 18 tests pass
- [ ] CI passes on all suites

Closes #172

Generated with [Claude Code](https://claude.com/claude-code)