### PR TITLE
feat: GitHub Pages documentation site with MkDocs Material auto-deploy

### DIFF
--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -1,0 +1,26 @@
+name: Validate Docs Build
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-material
+      - name: Copy root docs into docs/
+        run: |
+          cp GETTING_STARTED.md docs/GETTING_STARTED.md
+          cp API_REFERENCE.md docs/API_REFERENCE.md
+          cp CONTRIBUTING.md docs/CONTRIBUTING.md
+          cp TROUBLESHOOTING.md docs/TROUBLESHOOTING.md
+          cp CHANGELOG.md docs/CHANGELOG.md
+      - run: mkdocs build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+
+      - name: Copy root docs into docs/
+        run: |
+          cp GETTING_STARTED.md docs/GETTING_STARTED.md
+          cp API_REFERENCE.md docs/API_REFERENCE.md
+          cp CONTRIBUTING.md docs/CONTRIBUTING.md
+          cp TROUBLESHOOTING.md docs/TROUBLESHOOTING.md
+          cp CHANGELOG.md docs/CHANGELOG.md
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,16 @@ tmp/
 outputs/
 reports/
 
+# MkDocs build output
+site/
+
+# MkDocs CI-generated doc copies (generated at build time from root .md files)
+docs/GETTING_STARTED.md
+docs/API_REFERENCE.md
+docs/CONTRIBUTING.md
+docs/TROUBLESHOOTING.md
+docs/CHANGELOG.md
+
 # Amplihack runtime directories (auto-generated)
 .claude/logs/
 .claude/runtime/

--- a/docs/quality-audit-2026-02.md
+++ b/docs/quality-audit-2026-02.md
@@ -1,7 +1,7 @@
 # Quality Audit Report — February 2026
 
 > **Note:** This is a historical audit report from 2026-02-22. All issues identified have been resolved.
-> See the [CHANGELOG](../CHANGELOG.md) for details on each fix and the PRs that addressed them.
+> See the [CHANGELOG](CHANGELOG.md) for details on each fix and the PRs that addressed them.
 
 **Date:** 2026-02-21
 **Scope:** Full codebase (21,923 LOC, ~55 TypeScript source files)

--- a/docs/scenarios-README.md
+++ b/docs/scenarios-README.md
@@ -1,0 +1,438 @@
+# Test Scenarios
+
+This directory contains YAML-based test scenarios for the TypeScript Agentic Testing System. Each scenario defines comprehensive test workflows that can be executed by autonomous testing agents.
+
+## Overview
+
+Test scenarios are defined in YAML format and describe complex testing workflows that involve multiple agents working together. Use these scenarios with the `@gadugi/agentic-test` framework (`gadugi-test` CLI) to orchestrate agents that test Electron apps, CLI tools, and TUI applications.
+
+## Scenario Files
+
+### Core Test Scenarios
+
+1. **cli-tests.yaml** - CLI Command Testing
+   - Tests all core CLI commands (`atg --version`, `atg --help`, `atg build`, etc.)
+   - Validates error handling for missing parameters
+   - Tests command validation and help systems
+
+2. **ui-navigation.yaml** - UI Navigation Testing
+   - Tests navigation through all application tabs
+   - Verifies UI components load correctly
+   - Tests tab switching and state management
+
+3. **ui-workflows.yaml** - Complete UI Workflows
+   - End-to-end workflow testing for all major operations
+   - Tests Build, Generate Spec, Generate IaC, Configuration workflows
+   - Includes WebSocket communication testing
+
+4. **error-handling.yaml** - Error Scenario Testing
+   - Tests application behavior under various error conditions
+   - Validates error messages and recovery mechanisms
+   - Tests network failures, invalid inputs, and timeout scenarios
+
+5. **integration-tests.yaml** - Integration Testing
+   - Tests CLI-UI synchronization
+   - WebSocket communication validation
+   - Neo4j database integration testing
+   - Azure API interaction testing
+
+## Scenario File Structure
+
+Each YAML scenario file follows this standard structure:
+
+```yaml
+# Scenario metadata
+name: "Descriptive Scenario Name"
+description: "Detailed description of what this scenario tests"
+version: "1.0.0"
+
+# Test configuration
+config:
+  timeout: 120000      # Maximum time for entire scenario (ms)
+  retries: 2           # Number of retries on failure
+  parallel: false      # Whether steps can run in parallel
+
+# Environment requirements
+environment:
+  requires:            # Required environment variables
+    - REQUIRED_VAR_1
+    - REQUIRED_VAR_2
+  optional:            # Optional environment variables
+    - OPTIONAL_VAR_1
+
+# Agent definitions
+agents:
+  - name: "agent-name"
+    type: "agent-type"  # ui, system, websocket, database, api, network
+    config:
+      # Agent-specific configuration
+      
+# Test execution steps
+steps:
+  - name: "Step Description"
+    agent: "agent-name"
+    action: "action-name"
+    params:
+      # Action parameters
+    expect:
+      # Expected outcomes
+    timeout: 30000
+    wait_for:
+      # Conditions to wait for
+      
+# Validation assertions
+assertions:
+  - name: "Assertion Description"
+    type: "assertion-type"
+    agent: "agent-name"
+    params:
+      # Assertion parameters
+      
+# Cleanup actions
+cleanup:
+  - name: "Cleanup Description"
+    agent: "agent-name"
+    action: "cleanup-action"
+    
+# Metadata
+metadata:
+  tags: ["tag1", "tag2"]
+  priority: "high"
+  author: "author-name"
+  created: "ISO-date"
+  updated: "ISO-date"
+```
+
+## Agent Types
+
+### UI Agent (`type: "ui"`)
+Handles Electron application interactions via Playwright.
+
+**Configuration:**
+```yaml
+config:
+  browser: "chromium"     # Browser engine
+  headless: false         # Run with or without UI
+  viewport:
+    width: 1280
+    height: 720
+  timeout: 30000
+  slowMo: 500            # Slow down actions for stability
+```
+
+**Common Actions:**
+- `launch_electron` - Launch Electron application
+- `click` - Click on elements
+- `fill` - Fill form inputs
+- `wait_for_element` - Wait for element states
+- `multi_action` - Execute multiple actions sequentially
+- `execute_script` - Run JavaScript in the browser context
+- `close_app` - Close the application
+
+### System Agent (`type: "system"`)
+Executes command-line operations and system interactions.
+
+**Configuration:**
+```yaml
+config:
+  shell: "bash"           # Shell to use
+  cwd: "/path/to/directory"
+  timeout: 60000
+  capture_output: true    # Capture stdout/stderr
+```
+
+**Common Actions:**
+- `execute_command` - Execute shell commands
+- `check_process` - Check if processes are running
+- `file_operations` - File system operations
+
+### WebSocket Agent (`type: "websocket"`)
+Manages WebSocket connections and real-time communication.
+
+**Configuration:**
+```yaml
+config:
+  url: "ws://localhost:3001"
+  reconnect: true
+  timeout: 10000
+```
+
+**Common Actions:**
+- `connect` - Establish WebSocket connection
+- `listen` - Listen for specific events
+- `send_message` - Send messages
+- `disconnect` - Close connections
+
+### Database Agent (`type: "database"`)
+Handles database operations and testing.
+
+**Configuration:**
+```yaml
+config:
+  type: "neo4j"
+  host: "localhost"
+  port: "7687"
+  auth:
+    username: "neo4j"
+    password: "${NEO4J_PASSWORD}"
+  timeout: 15000
+```
+
+**Common Actions:**
+- `connect` - Connect to database
+- `execute_query` - Run database queries
+- `stress_test` - Performance testing
+- `disconnect` - Close connections
+
+### API Agent (`type: "api"`)
+Tests REST API endpoints and external service integrations.
+
+**Configuration:**
+```yaml
+config:
+  timeout: 30000
+  retry_count: 3
+```
+
+**Common Actions:**
+- `authenticate_azure` - Azure authentication
+- `call_api` - HTTP API calls
+- `test_endpoints` - Endpoint validation
+
+### Network Agent (`type: "network"`)
+Simulates network conditions and failures.
+
+**Configuration:**
+```yaml
+config:
+  can_simulate_failures: true
+  timeout: 10000
+```
+
+**Common Actions:**
+- `block_port` - Block network ports
+- `unblock_port` - Restore network access
+- `simulate_latency` - Add network delays
+
+## Writing New Scenarios
+
+### 1. Define the Scenario Purpose
+Start by clearly defining what your scenario will test:
+- What functionality or workflow?
+- What success criteria?
+- What failure modes to test?
+
+### 2. Choose Appropriate Agents
+Select the agents needed for your test:
+- UI testing: `ui-agent`
+- CLI operations: `system-agent`
+- Real-time updates: `websocket-agent`
+- Database operations: `database-agent`
+- API testing: `api-agent`
+- Network conditions: `network-agent`
+
+### 3. Plan the Test Steps
+Break down your test into logical steps:
+1. Setup/initialization
+2. Main test actions
+3. Verification/validation
+4. Cleanup
+
+### 4. Define Environment Requirements
+List all environment variables needed:
+- Required: Variables that must be present
+- Optional: Variables that enhance testing but aren't mandatory
+
+### 5. Write Comprehensive Assertions
+Include assertions that validate:
+- Expected outcomes occurred
+- No unexpected errors happened
+- System remains in valid state
+- Performance criteria met
+
+### 6. Include Proper Cleanup
+Always include cleanup steps to:
+- Close applications and connections
+- Remove test data
+- Restore system state
+- Clean up temporary files
+
+## Best Practices
+
+### Naming Conventions
+- Scenario files: `kebab-case.yaml`
+- Step names: "Descriptive Action Description"
+- Agent names: "purpose-agent" (e.g., "ui-agent", "cli-agent")
+
+### Timeout Management
+- Set appropriate timeouts for each step
+- Consider network latency and system performance
+- Use longer timeouts for integration tests
+- Use shorter timeouts for unit-style tests
+
+### Error Handling
+- Include `expect_failure: true` for negative tests
+- Use `optional: true` for steps that may not apply
+- Include `ignore_errors: true` in cleanup steps
+- Test both success and failure scenarios
+
+### Environment Variables
+- Use `${VAR_NAME}` syntax for variable substitution
+- Provide defaults where appropriate: `${VAR_NAME:-default_value}`
+- Document all required variables in the environment section
+
+### Test Data Management
+- Use unique identifiers: `test-${TIMESTAMP}`
+- Clean up test data in cleanup section
+- Don't rely on persistent state between tests
+
+### Documentation
+- Use descriptive names and descriptions
+- Include comments for complex steps
+- Tag scenarios appropriately for filtering
+- Update metadata when modifying scenarios
+
+## Example Minimal Scenario
+
+```yaml
+name: "Simple UI Test"
+description: "Basic UI interaction test"
+version: "1.0.0"
+
+config:
+  timeout: 60000
+  retries: 1
+  parallel: false
+
+environment:
+  requires:
+    - ELECTRON_APP_PATH
+
+agents:
+  - name: "ui-agent"
+    type: "ui"
+    config:
+      browser: "chromium"
+      headless: false
+      timeout: 30000
+
+steps:
+  - name: "Launch App"
+    agent: "ui-agent"
+    action: "launch_electron"
+    params:
+      executablePath: "${ELECTRON_APP_PATH}"
+    timeout: 20000
+    
+  - name: "Click Button"
+    agent: "ui-agent"
+    action: "click"
+    params:
+      selector: "[data-testid='test-button']"
+    wait_for:
+      selector: "[data-testid='result']"
+      state: "visible"
+
+assertions:
+  - name: "Result Displayed"
+    type: "element_visible"
+    agent: "ui-agent"
+    params:
+      selector: "[data-testid='result']"
+
+cleanup:
+  - name: "Close App"
+    agent: "ui-agent"
+    action: "close_app"
+
+metadata:
+  tags: ["ui", "simple"]
+  priority: "medium"
+  author: "developer"
+  created: "2024-09-03T00:00:00Z"
+```
+
+## Running Scenarios
+
+Scenarios are executed by the TypeScript Agentic Testing System orchestrator. The system will:
+
+1. Parse the YAML scenario
+2. Validate environment requirements
+3. Initialize specified agents
+4. Execute steps in sequence
+5. Run assertions to validate outcomes
+6. Execute cleanup procedures
+7. Generate comprehensive reports
+
+For more information on running scenarios, see the [Getting Started guide](GETTING_STARTED.md).
+
+## Schema Notes
+
+### Stable Scenario IDs
+
+The `id` field in a scenario definition is now a deterministic slug derived from the scenario `name`. You do not need to set `id` manually — the framework generates a stable identifier from the name, so scenario IDs remain consistent across runs and across team members:
+
+```yaml
+name: "CLI Smoke Test"
+# id is automatically: "cli-smoke-test"
+```
+
+Previously, each load generated a new UUID, which made cross-run comparisons unreliable.
+
+### Agents Array Validation
+
+The `agents` array is now validated on load. A scenario with an empty or missing `agents` field is rejected with a clear error message:
+
+```yaml
+# Valid — at least one agent required
+agents:
+  - name: "cli-agent"
+    type: "system"
+    config:
+      shell: "bash"
+```
+
+Running a scenario with no agents defined will produce an error like:
+
+```
+ScenarioValidationError: scenario "My Test" must define at least one agent
+```
+
+### Package Name
+
+All programmatic usage should import from `@gadugi/agentic-test`:
+
+```typescript
+import { runScenario, loadScenarios } from "@gadugi/agentic-test";
+
+const scenarios = await loadScenarios("./scenarios");
+await runScenario(scenarios[0]);
+```
+
+The CLI binary is `gadugi-test`:
+
+```bash
+gadugi-test run scenarios/my-test.yaml
+```
+
+## Contributing
+
+When adding new scenarios:
+
+1. Follow the established naming conventions
+2. Include comprehensive test coverage
+3. Add appropriate metadata and tags
+4. Test your scenario thoroughly
+5. Update this README if introducing new patterns
+6. Consider both positive and negative test cases
+
+## Troubleshooting
+
+Common issues when writing scenarios:
+
+- **Timeouts**: Increase timeout values for slow operations
+- **Element selectors**: Use `data-testid` attributes for reliable selection
+- **Environment variables**: Ensure all required variables are documented
+- **Agent configuration**: Verify agent types and configurations are valid
+- **Step dependencies**: Ensure steps execute in logical order
+- **Cleanup failures**: Use `ignore_errors: true` for non-critical cleanup steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,58 @@
+site_name: Gadugi Agentic Test
+site_description: Intelligent multi-agent testing framework for Electron, CLI, and web applications
+site_url: https://rysweet.github.io/gadugi-agentic-test/
+repo_url: https://github.com/rysweet/gadugi-agentic-test
+repo_name: rysweet/gadugi-agentic-test
+edit_uri: edit/main/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: GETTING_STARTED.md
+  - Architecture: ARCHITECTURE.md
+  - API Reference: API_REFERENCE.md
+  - Guides:
+    - Contributing: CONTRIBUTING.md
+    - Writing Scenarios: scenarios-README.md
+    - Screenshot Diffing: screenshot-diff-guide.md
+    - Resource Optimization: ResourceOptimizer.md
+  - Reference:
+    - Troubleshooting: TROUBLESHOOTING.md
+    - Changelog: CHANGELOG.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/rysweet/gadugi-agentic-test


### PR DESCRIPTION
## Summary

- Adds `mkdocs.yml` with MkDocs Material theme configuration (dark/light toggle, tabs, search, code copy)
- Adds `.github/workflows/docs.yml` — deploys to GitHub Pages on any `.md` or `docs/` change merged to `main`
- Adds `.github/workflows/docs-pr-preview.yml` — validates `mkdocs build` on every PR touching docs
- Adds `docs/scenarios-README.md` — docs-specific version of the scenarios guide with corrected internal links
- Updates `.gitignore` to exclude `site/` (MkDocs build output) and CI-generated doc copies

## How it works

The CI `docs.yml` workflow:
1. Checks out the repo
2. Copies root-level `.md` files (`GETTING_STARTED.md`, `API_REFERENCE.md`, `CONTRIBUTING.md`, `TROUBLESHOOTING.md`, `CHANGELOG.md`) into `docs/` at build time
3. Runs `mkdocs gh-deploy --force` which builds the site and pushes to the `gh-pages` branch

The homepage (`docs/index.md`) is the existing documentation navigation page.

After this PR merges, enable GitHub Pages in repo Settings → Pages, source: `gh-pages` branch, `/` path.

## Site URL

https://rysweet.github.io/gadugi-agentic-test/

## Notes

- `docs/scenarios-README.md` is a maintained copy of `scenarios/README.md` with `.yaml` file links removed (those links can't resolve in the MkDocs context)
- Root `.md` files are not modified — they continue to work as-is on GitHub
- `mkdocs build` succeeds locally once the CI copy step is run manually

## Test plan

- [ ] CI `Validate Docs Build` workflow passes on this PR
- [ ] After merge, `Deploy Documentation` workflow runs and pushes to `gh-pages` branch
- [ ] Enable GitHub Pages in repo settings (source: `gh-pages` branch)
- [ ] Site loads at https://rysweet.github.io/gadugi-agentic-test/
- [ ] Dark/light mode toggle works
- [ ] All nav entries render correctly

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)