### PR TITLE
fix: add prepare script so git-based installs build dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "start": "node dist/cli.js",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build",
     "docs": "typedoc && mkdocs serve",
     "docs:build": "typedoc && mkdocs build --strict"


### PR DESCRIPTION
## Problem

`npm install -g` from a git clone or git URL fails with:

```
Error: Cannot find module './logging/LogTransport'
```

This happens because `dist/` is in `.gitignore`, so it's not present in git checkouts. The `prepublishOnly` script only runs on `npm publish`, not on `npm install`.

## Fix

Add a `prepare` lifecycle script that runs `npm run build`. The `prepare` hook runs on:
- `npm install` (from local path or git URL)
- `npm publish` (before `prepublishOnly`)

This ensures `dist/` is always built regardless of install method.

## Verification

```bash
rm -rf dist && npm install -g .  # prepare triggers build
gadugi-test --help               # works, no LogTransport error
ls dist/utils/logging/           # LogTransport.js present
```