### PR TITLE
fix: handle undefined docker metrics in SystemAgent test

### DIFF
--- a/src/agents/__tests__/SystemAgent.test.ts
+++ b/src/agents/__tests__/SystemAgent.test.ts
@@ -225,7 +225,7 @@ describe('SystemAgent', () => {
       const metrics = await agent.captureMetrics();
       
       // Should not crash even if Docker is not available
-      expect(metrics.docker).toBeDefined();
+      // metrics.docker may be undefined when Docker daemon is not running
       if (metrics.docker) {
         expect(Array.isArray(metrics.docker)).toBe(true);
       }


### PR DESCRIPTION
The Docker monitoring test assumed metrics.docker would always be defined, but it is undefined when Docker daemon is not running. This caused a test failure in CI environments without Docker.

Remove the toBeDefined() assertion and only validate the array type when present.

## Changes
- `src/agents/__tests__/SystemAgent.test.ts`: Relax assertion on metrics.docker to handle undefined gracefully

## Test
All 1747 tests pass (1745 pass, 1 skip, 0 fail).